### PR TITLE
feat(talks): Replace Yourself with Agents — external conference talk

### DIFF
--- a/app/talks/replace-yourself-with-agents/layout.tsx
+++ b/app/talks/replace-yourself-with-agents/layout.tsx
@@ -1,0 +1,19 @@
+import { Metadata } from 'next';
+
+export const metadata: Metadata = {
+  title: 'The agent funnel | Tulsi Sapkota',
+  description:
+    'Building an autonomous CI optimizer — a talk about agent funnels, BFF-style MCPs, and the lessons learned.',
+};
+
+/**
+ * Fullscreen presentation layout — overlays the site Header/Footer via
+ * fixed z-[100] positioning so the root layout is untouched.
+ */
+export default function TalkLayout({ children }: { children: React.ReactNode }) {
+  return (
+    <div className="fixed inset-0 z-[100] bg-[#282c35] overflow-hidden">
+      {children}
+    </div>
+  );
+}

--- a/app/talks/replace-yourself-with-agents/page.tsx
+++ b/app/talks/replace-yourself-with-agents/page.tsx
@@ -1,0 +1,17 @@
+'use client';
+
+import { Deck } from '@/components/talks/pipeline-optimizer/deck';
+import { Slide } from '@/components/talks/pipeline-optimizer/slide';
+import { slides } from '@/components/talks/pipeline-optimizer/slides-data';
+
+export default function PipelineOptimizerTalkPage() {
+  return (
+    <Deck>
+      {slides.map((slide) => (
+        <Slide key={slide.id} title={slide.title} notes={slide.notes}>
+          {slide.content}
+        </Slide>
+      ))}
+    </Deck>
+  );
+}

--- a/app/talks/replace-yourself-with-agents/presenter/page.tsx
+++ b/app/talks/replace-yourself-with-agents/presenter/page.tsx
@@ -1,0 +1,243 @@
+'use client';
+
+/**
+ * Presenter view for "Replace Yourself with Agents"
+ *
+ * Open this route in a second window (/talks/replace-yourself-with-agents/presenter).
+ * It syncs slide position bidirectionally with the audience window via
+ * BroadcastChannel('pipeline-optimizer-talk-sync').
+ *
+ * Layout:
+ *   Header: PRESENTER label | slide counter | elapsed timer
+ *   Body:   left 30% = current slide thumbnail + next preview
+ *           right 70% = speaker notes (large, scrollable)
+ *   Footer: keyboard hint
+ */
+
+import { useEffect, useRef, useState } from 'react';
+import { Slide } from '@/components/talks/pipeline-optimizer/slide';
+import { slides } from '@/components/talks/pipeline-optimizer/slides-data';
+import { sans } from '@/lib/fonts';
+
+const CHANNEL = 'pipeline-optimizer-talk-sync';
+const TOTAL = slides.length;
+/** Native slide dimensions (matches <Deck> frame) */
+const SLIDE_W = 1280;
+const SLIDE_H = 720;
+
+function formatTime(s: number): string {
+  const m = Math.floor(s / 60);
+  const sec = s % 60;
+  return `${String(m).padStart(2, '0')}:${String(sec).padStart(2, '0')}`;
+}
+
+// ─── Slide thumbnail ─────────────────────────────────────────────────────────
+
+interface ThumbnailProps {
+  index: number;
+  /** Rendered pixel width — height is derived from 16:9 aspect ratio */
+  width: number;
+}
+
+function SlideThumbnail({ index, width }: ThumbnailProps) {
+  const scale = width / SLIDE_W;
+  const height = Math.round(SLIDE_H * scale);
+  const slide = slides[index];
+
+  return (
+    <div
+      style={{ width, height, flexShrink: 0 }}
+      className="relative overflow-hidden rounded-lg bg-[#1c1e26] border border-white/10"
+    >
+      {slide ? (
+        <div
+          style={{
+            position: 'absolute',
+            top: 0,
+            left: 0,
+            width: SLIDE_W,
+            height: SLIDE_H,
+            transformOrigin: 'top left',
+            transform: `scale(${scale})`,
+            pointerEvents: 'none',
+            userSelect: 'none',
+          }}
+        >
+          {/* <Slide> uses absolute inset-0, so needs a relative-positioned parent */}
+          <div className="relative w-full h-full">
+            <Slide title={slide.title}>{slide.content}</Slide>
+          </div>
+        </div>
+      ) : (
+        <div className="w-full h-full flex items-center justify-center">
+          <span className="font-mono text-xs text-white/25">End</span>
+        </div>
+      )}
+    </div>
+  );
+}
+
+// ─── Presenter page ───────────────────────────────────────────────────────────
+
+export default function PresenterPage() {
+  const [current, setCurrent] = useState(0);
+  const [elapsed, setElapsed] = useState(0);
+
+  // BroadcastChannel state — isRemoteUpdate prevents echo loops when the
+  // audience window pushes a nav and we shouldn't broadcast it back.
+  const channelRef = useRef<BroadcastChannel | null>(null);
+  const isRemoteUpdate = useRef(false);
+
+  // Thumbnail width — measured from the left-column container
+  const thumbContainerRef = useRef<HTMLDivElement>(null);
+  const [thumbWidth, setThumbWidth] = useState(400);
+
+  const activeSlide = slides[current];
+  const nextSlide = slides[current + 1];
+
+  // Elapsed timer — auto-starts on mount
+  useEffect(() => {
+    const id = setInterval(() => setElapsed((s) => s + 1), 1000);
+    return () => clearInterval(id);
+  }, []);
+
+  // Measure left column for responsive thumbnail width
+  useEffect(() => {
+    const el = thumbContainerRef.current;
+    if (!el) return;
+    const ro = new ResizeObserver((entries) => {
+      const w = entries[0]?.contentRect.width;
+      if (w) setThumbWidth(Math.round(w));
+    });
+    ro.observe(el);
+    return () => ro.disconnect();
+  }, []);
+
+  // BroadcastChannel — bidirectional sync with audience window
+  useEffect(() => {
+    if (typeof BroadcastChannel === 'undefined') return;
+    const ch = new BroadcastChannel(CHANNEL);
+    channelRef.current = ch;
+    ch.onmessage = (e: MessageEvent) => {
+      const { type, index } = (e.data ?? {}) as { type?: string; index?: number };
+      if (type === 'nav' && typeof index === 'number') {
+        isRemoteUpdate.current = true;
+        setCurrent(Math.min(Math.max(index, 0), TOTAL - 1));
+      }
+    };
+    // Ask audience window for its current position
+    ch.postMessage({ type: 'sync_request' });
+    return () => ch.close();
+  }, []);
+
+  // Broadcast local navigation to audience window
+  useEffect(() => {
+    if (isRemoteUpdate.current) {
+      isRemoteUpdate.current = false;
+      return;
+    }
+    channelRef.current?.postMessage({ type: 'nav', index: current });
+  }, [current]);
+
+  // Keyboard navigation — mirrors deck.tsx bindings
+  useEffect(() => {
+    function handleKey(e: KeyboardEvent) {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+      switch (e.key) {
+        case 'ArrowRight':
+        case 'ArrowDown':
+        case ' ':
+          e.preventDefault();
+          setCurrent((c) => Math.min(c + 1, TOTAL - 1));
+          break;
+        case 'ArrowLeft':
+        case 'ArrowUp':
+          e.preventDefault();
+          setCurrent((c) => Math.max(c - 1, 0));
+          break;
+        case 'Escape':
+          e.preventDefault();
+          setCurrent(0);
+          break;
+      }
+    }
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, []);
+
+  return (
+    <div
+      className={`w-full h-full flex flex-col bg-[#0d0f14] text-white overflow-hidden ${sans.className}`}
+    >
+      {/* ── Header ─────────────────────────────────────────────────────── */}
+      <div className="flex items-center justify-between px-6 py-3 border-b border-white/10 shrink-0">
+        <span className="font-mono text-xs text-white/35 uppercase tracking-wider">
+          Presenter
+        </span>
+        <span className="font-mono text-sm text-white/55">
+          {current + 1}
+          <span className="text-white/25"> / {TOTAL}</span>
+        </span>
+        <span className="font-mono text-2xl font-bold tabular-nums text-white/80">
+          {formatTime(elapsed)}
+        </span>
+      </div>
+
+      {/* ── Main ───────────────────────────────────────────────────────── */}
+      <div className="flex flex-1 min-h-0">
+        {/* Left column — current + next thumbnails (30%) */}
+        <div className="flex flex-col shrink-0 w-[30%] border-r border-white/10 overflow-y-auto">
+          {/* Inner div measured for thumbnail width */}
+          <div ref={thumbContainerRef} className="flex flex-col gap-5 p-5">
+            {/* Current slide */}
+            <div>
+              <p className="font-mono text-[10px] text-white/30 uppercase tracking-widest mb-2 truncate">
+                Current{activeSlide?.title ? ` — ${activeSlide.title}` : ''}
+              </p>
+              <SlideThumbnail key={`curr-${current}`} index={current} width={thumbWidth} />
+            </div>
+
+            {/* Next slide */}
+            {nextSlide && (
+              <div>
+                <p className="font-mono text-[10px] text-white/20 uppercase tracking-widest mb-2 truncate">
+                  Next{nextSlide.title ? ` — ${nextSlide.title}` : ''}
+                </p>
+                <SlideThumbnail
+                  key={`next-${current}`}
+                  index={current + 1}
+                  width={Math.round(thumbWidth * 0.6)}
+                />
+              </div>
+            )}
+
+            {!nextSlide && current === TOTAL - 1 && (
+              <p className="font-mono text-xs text-white/20 italic">Last slide</p>
+            )}
+          </div>
+        </div>
+
+        {/* Right column — speaker notes (70%) */}
+        <div className="flex-1 flex flex-col min-h-0 overflow-y-auto p-8">
+          <p className="font-mono text-[10px] text-white/30 uppercase tracking-widest mb-6 shrink-0">
+            Speaker notes
+          </p>
+          {activeSlide?.notes ? (
+            <p className="text-xl leading-relaxed text-white/88 whitespace-pre-wrap">
+              {activeSlide.notes}
+            </p>
+          ) : (
+            <p className="text-lg italic text-white/25">No notes for this slide.</p>
+          )}
+        </div>
+      </div>
+
+      {/* ── Footer ─────────────────────────────────────────────────────── */}
+      <div className="flex items-center px-6 py-3 border-t border-white/10 shrink-0">
+        <span className="font-mono text-[10px] text-white/20">
+          ← → Space &nbsp;navigate &nbsp;·&nbsp; Esc &nbsp;restart
+        </span>
+      </div>
+    </div>
+  );
+}

--- a/package.json
+++ b/package.json
@@ -25,6 +25,7 @@
     "react": "^18.3.1",
     "react-dom": "^18.3.1",
     "react-svg": "^16.3.0",
+    "reactflow": "^11.11.4",
     "remark": "^14.0.3",
     "remark-gfm": "^3.0.1",
     "remark-github-blockquote-alert": "^1.3.1",

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -56,6 +56,9 @@ importers:
       react-svg:
         specifier: ^16.3.0
         version: 16.3.0(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      reactflow:
+        specifier: ^11.11.4
+        version: 11.11.4(@types/react@18.0.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
       remark:
         specifier: ^14.0.3
         version: 14.0.3
@@ -858,6 +861,42 @@ packages:
       '@types/react':
         optional: true
 
+  '@reactflow/background@11.3.14':
+    resolution: {integrity: sha512-Gewd7blEVT5Lh6jqrvOgd4G6Qk17eGKQfsDXgyRSqM+CTwDqRldG2LsWN4sNeno6sbqVIC2fZ+rAUBFA9ZEUDA==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@reactflow/controls@11.2.14':
+    resolution: {integrity: sha512-MiJp5VldFD7FrqaBNIrQ85dxChrG6ivuZ+dcFhPQUwOK3HfYgX2RHdBua+gx+40p5Vw5It3dVNp/my4Z3jF0dw==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@reactflow/core@11.11.4':
+    resolution: {integrity: sha512-H4vODklsjAq3AMq6Np4LE12i1I4Ta9PrDHuBR9GmL8uzTt2l2jh4CiQbEMpvMDcp7xi4be0hgXj+Ysodde/i7Q==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@reactflow/minimap@11.7.14':
+    resolution: {integrity: sha512-mpwLKKrEAofgFJdkhwR5UQ1JYWlcAAL/ZU/bctBkuNTT1yqV+y0buoNVImsRehVYhJwffSWeSHaBR5/GJjlCSQ==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@reactflow/node-resizer@2.2.14':
+    resolution: {integrity: sha512-fwqnks83jUlYr6OHcdFEedumWKChTHRGw/kbCxj0oqBd+ekfs+SIp4ddyNU0pdx96JIm5iNFS0oNrmEiJbbSaA==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
+  '@reactflow/node-toolbar@1.3.14':
+    resolution: {integrity: sha512-rbynXQnH/xFNu4P9H+hVqlEUafDCkEoCy0Dg9mG22Sg+rY/0ck6KkrAQrYrTgXusd+cEJOMK0uOOFCK2/5rSGQ==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
   '@rtsao/scc@1.1.0':
     resolution: {integrity: sha512-zt6OdqaDoOnJ1ZYsCYGt9YmWzDXl4vQdKTyJev62gFhRGKdx7mcT54V9KIjg+d2wi9EXsPvAPKe7i7WjfVWB8g==}
 
@@ -970,8 +1009,104 @@ packages:
   '@tybys/wasm-util@0.10.0':
     resolution: {integrity: sha512-VyyPYFlOMNylG45GoAe0xDoLwWuowvf92F9kySqzYh8vmYm7D2u4iUJKa1tOUpS70Ku13ASrOkS4ScXFsTaCNQ==}
 
+  '@types/d3-array@3.2.2':
+    resolution: {integrity: sha512-hOLWVbm7uRza0BYXpIIW5pxfrKe0W+D5lrFiAEYR+pb6w3N2SwSMaJbXdUfSEv+dT4MfHBLtn5js0LAWaO6otw==}
+
+  '@types/d3-axis@3.0.6':
+    resolution: {integrity: sha512-pYeijfZuBd87T0hGn0FO1vQ/cgLk6E1ALJjfkC0oJ8cbwkZl3TpgS8bVBLZN+2jjGgg38epgxb2zmoGtSfvgMw==}
+
+  '@types/d3-brush@3.0.6':
+    resolution: {integrity: sha512-nH60IZNNxEcrh6L1ZSMNA28rj27ut/2ZmI3r96Zd+1jrZD++zD3LsMIjWlvg4AYrHn/Pqz4CF3veCxGjtbqt7A==}
+
+  '@types/d3-chord@3.0.6':
+    resolution: {integrity: sha512-LFYWWd8nwfwEmTZG9PfQxd17HbNPksHBiJHaKuY1XeqscXacsS2tyoo6OdRsjf+NQYeB6XrNL3a25E3gH69lcg==}
+
+  '@types/d3-color@3.1.3':
+    resolution: {integrity: sha512-iO90scth9WAbmgv7ogoq57O9YpKmFBbmoEoCHDB2xMBY0+/KVrqAaCDyCE16dUspeOvIxFFRI+0sEtqDqy2b4A==}
+
+  '@types/d3-contour@3.0.6':
+    resolution: {integrity: sha512-BjzLgXGnCWjUSYGfH1cpdo41/hgdWETu4YxpezoztawmqsvCeep+8QGfiY6YbDvfgHz/DkjeIkkZVJavB4a3rg==}
+
+  '@types/d3-delaunay@6.0.4':
+    resolution: {integrity: sha512-ZMaSKu4THYCU6sV64Lhg6qjf1orxBthaC161plr5KuPHo3CNm8DTHiLw/5Eq2b6TsNP0W0iJrUOFscY6Q450Hw==}
+
+  '@types/d3-dispatch@3.0.7':
+    resolution: {integrity: sha512-5o9OIAdKkhN1QItV2oqaE5KMIiXAvDWBDPrD85e58Qlz1c1kI/J0NcqbEG88CoTwJrYe7ntUCVfeUl2UJKbWgA==}
+
+  '@types/d3-drag@3.0.7':
+    resolution: {integrity: sha512-HE3jVKlzU9AaMazNufooRJ5ZpWmLIoc90A37WU2JMmeq28w1FQqCZswHZ3xR+SuxYftzHq6WU6KJHvqxKzTxxQ==}
+
+  '@types/d3-dsv@3.0.7':
+    resolution: {integrity: sha512-n6QBF9/+XASqcKK6waudgL0pf/S5XHPPI8APyMLLUHd8NqouBGLsU8MgtO7NINGtPBtk9Kko/W4ea0oAspwh9g==}
+
+  '@types/d3-ease@3.0.2':
+    resolution: {integrity: sha512-NcV1JjO5oDzoK26oMzbILE6HW7uVXOHLQvHshBUW4UMdZGfiY6v5BeQwh9a9tCzv+CeefZQHJt5SRgK154RtiA==}
+
+  '@types/d3-fetch@3.0.7':
+    resolution: {integrity: sha512-fTAfNmxSb9SOWNB9IoG5c8Hg6R+AzUHDRlsXsDZsNp6sxAEOP0tkP3gKkNSO/qmHPoBFTxNrjDprVHDQDvo5aA==}
+
+  '@types/d3-force@3.0.10':
+    resolution: {integrity: sha512-ZYeSaCF3p73RdOKcjj+swRlZfnYpK1EbaDiYICEEp5Q6sUiqFaFQ9qgoshp5CzIyyb/yD09kD9o2zEltCexlgw==}
+
+  '@types/d3-format@3.0.4':
+    resolution: {integrity: sha512-fALi2aI6shfg7vM5KiR1wNJnZ7r6UuggVqtDA+xiEdPZQwy/trcQaHnwShLuLdta2rTymCNpxYTiMZX/e09F4g==}
+
+  '@types/d3-geo@3.1.0':
+    resolution: {integrity: sha512-856sckF0oP/diXtS4jNsiQw/UuK5fQG8l/a9VVLeSouf1/PPbBE1i1W852zVwKwYCBkFJJB7nCFTbk6UMEXBOQ==}
+
+  '@types/d3-hierarchy@3.1.7':
+    resolution: {integrity: sha512-tJFtNoYBtRtkNysX1Xq4sxtjK8YgoWUNpIiUee0/jHGRwqvzYxkq0hGVbbOGSz+JgFxxRu4K8nb3YpG3CMARtg==}
+
+  '@types/d3-interpolate@3.0.4':
+    resolution: {integrity: sha512-mgLPETlrpVV1YRJIglr4Ez47g7Yxjl1lj7YKsiMCb27VJH9W8NVM6Bb9d8kkpG/uAQS5AmbA48q2IAolKKo1MA==}
+
+  '@types/d3-path@3.1.1':
+    resolution: {integrity: sha512-VMZBYyQvbGmWyWVea0EHs/BwLgxc+MKi1zLDCONksozI4YJMcTt8ZEuIR4Sb1MMTE8MMW49v0IwI5+b7RmfWlg==}
+
+  '@types/d3-polygon@3.0.2':
+    resolution: {integrity: sha512-ZuWOtMaHCkN9xoeEMr1ubW2nGWsp4nIql+OPQRstu4ypeZ+zk3YKqQT0CXVe/PYqrKpZAi+J9mTs05TKwjXSRA==}
+
+  '@types/d3-quadtree@3.0.6':
+    resolution: {integrity: sha512-oUzyO1/Zm6rsxKRHA1vH0NEDG58HrT5icx/azi9MF1TWdtttWl0UIUsjEQBBh+SIkrpd21ZjEv7ptxWys1ncsg==}
+
+  '@types/d3-random@3.0.3':
+    resolution: {integrity: sha512-Imagg1vJ3y76Y2ea0871wpabqp613+8/r0mCLEBfdtqC7xMSfj9idOnmBYyMoULfHePJyxMAw3nWhJxzc+LFwQ==}
+
+  '@types/d3-scale-chromatic@3.1.0':
+    resolution: {integrity: sha512-iWMJgwkK7yTRmWqRB5plb1kadXyQ5Sj8V/zYlFGMUBbIPKQScw+Dku9cAAMgJG+z5GYDoMjWGLVOvjghDEFnKQ==}
+
+  '@types/d3-scale@4.0.9':
+    resolution: {integrity: sha512-dLmtwB8zkAeO/juAMfnV+sItKjlsw2lKdZVVy6LRr0cBmegxSABiLEpGVmSJJ8O08i4+sGR6qQtb6WtuwJdvVw==}
+
+  '@types/d3-selection@3.0.11':
+    resolution: {integrity: sha512-bhAXu23DJWsrI45xafYpkQ4NtcKMwWnAC/vKrd2l+nxMFuvOT3XMYTIj2opv8vq8AO5Yh7Qac/nSeP/3zjTK0w==}
+
+  '@types/d3-shape@3.1.8':
+    resolution: {integrity: sha512-lae0iWfcDeR7qt7rA88BNiqdvPS5pFVPpo5OfjElwNaT2yyekbM0C9vK+yqBqEmHr6lDkRnYNoTBYlAgJa7a4w==}
+
+  '@types/d3-time-format@4.0.3':
+    resolution: {integrity: sha512-5xg9rC+wWL8kdDj153qZcsJ0FWiFt0J5RB6LYUNZjwSnesfblqrI/bJ1wBdJ8OQfncgbJG5+2F+qfqnqyzYxyg==}
+
+  '@types/d3-time@3.0.4':
+    resolution: {integrity: sha512-yuzZug1nkAAaBlBBikKZTgzCeA+k1uy4ZFwWANOfKw5z5LRhV0gNA7gNkKm7HoK+HRN0wX3EkxGk0fpbWhmB7g==}
+
+  '@types/d3-timer@3.0.2':
+    resolution: {integrity: sha512-Ps3T8E8dZDam6fUyNiMkekK3XUsaUEik+idO9/YjPtfj2qruF8tFBXS7XhtE4iIXBLxhmLjP3SXpLhVf21I9Lw==}
+
+  '@types/d3-transition@3.0.9':
+    resolution: {integrity: sha512-uZS5shfxzO3rGlu0cC3bjmMFKsXv+SmZZcgp0KD22ts4uGXp5EVYGzu/0YdwZeKmddhcAccYtREJKkPfXkZuCg==}
+
+  '@types/d3-zoom@3.0.8':
+    resolution: {integrity: sha512-iqMC4/YlFCSlO8+2Ii1GGGliCAY4XdeG748w5vQUbevlbDu0zSjH/+jojorQVBK/se0j6DUFNPBGSqD3YWYnDw==}
+
+  '@types/d3@7.4.3':
+    resolution: {integrity: sha512-lZXZ9ckh5R8uiFVt8ogUNf+pIrK4EsWrx2Np75WvF/eTpJ0FMHNhjXk8CKEx/+gpHbNQyJWehbFaTvqmHWB3ww==}
+
   '@types/debug@4.1.12':
     resolution: {integrity: sha512-vIChWdVG3LG1SMxEvI/AK+FWJthlrqlTu7fbrlywTkkaONwk/UAGaULXRlf8vkzFBLVm0zkMdCquhL5aOjhXPQ==}
+
+  '@types/geojson@7946.0.16':
+    resolution: {integrity: sha512-6C8nqWur3j98U6+lXDfTUWIfgvZU+EumvpHKcYjujKH7woYyLj2sUmff0tRhrqM7BohUw7Pz3ZB1jj2gW9Fvmg==}
 
   '@types/hast@2.3.10':
     resolution: {integrity: sha512-McWspRw8xx8J9HurkVBfYj0xKoE25tOFlHGdx4MJ5xORQrMGZNqJhVQWaIbm6Oyla5kYOXtDiopzKRJzEOkwJw==}
@@ -1402,6 +1537,9 @@ packages:
   class-variance-authority@0.7.1:
     resolution: {integrity: sha512-Ka+9Trutv7G8M6WT6SeiRWz792K5qEqIGEGzXKhAE6xOWAY6pPH8U+9IY3oCMv6kqTmLsv7Xh/2w2RigkePMsg==}
 
+  classcat@5.0.5:
+    resolution: {integrity: sha512-JhZUT7JFcQy/EzW605k/ktHtncoo9vnyW/2GspNYwFlN1C/WmjuV/xtS04e9SOkL2sTdw0VAZ2UGCcQ9lR6p6w==}
+
   classnames@2.5.1:
     resolution: {integrity: sha512-saHYOzhIQs6wy2sVxTM6bUDsQO4F50V9RQ22qBpEdCW+I+/Wmke2HOl6lS6dTpdxVhb88/I6+Hs+438c3lfUow==}
 
@@ -1502,6 +1640,44 @@ packages:
 
   csstype@3.1.3:
     resolution: {integrity: sha512-M1uQkMl8rQK/szD0LNhtqxIPLpimGm8sOBwU7lLnCpSbTyY3yeU1Vc7l4KT5zT4s/yOxHH5O7tIuuLOCnLADRw==}
+
+  d3-color@3.1.0:
+    resolution: {integrity: sha512-zg/chbXyeBtMQ1LbD/WSoW2DpC3I0mpmPdW+ynRTj/x2DAWYrIY7qeZIHidozwV24m4iavr15lNwIwLxRmOxhA==}
+    engines: {node: '>=12'}
+
+  d3-dispatch@3.0.1:
+    resolution: {integrity: sha512-rzUyPU/S7rwUflMyLc1ETDeBj0NRuHKKAcvukozwhshr6g6c5d8zh4c2gQjY2bZ0dXeGLWc1PF174P2tVvKhfg==}
+    engines: {node: '>=12'}
+
+  d3-drag@3.0.0:
+    resolution: {integrity: sha512-pWbUJLdETVA8lQNJecMxoXfH6x+mO2UQo8rSmZ+QqxcbyA3hfeprFgIT//HW2nlHChWeIIMwS2Fq+gEARkhTkg==}
+    engines: {node: '>=12'}
+
+  d3-ease@3.0.1:
+    resolution: {integrity: sha512-wR/XK3D3XcLIZwpbvQwQ5fK+8Ykds1ip7A2Txe0yxncXSdq1L9skcG7blcedkOX+ZcgxGAmLX1FrRGbADwzi0w==}
+    engines: {node: '>=12'}
+
+  d3-interpolate@3.0.1:
+    resolution: {integrity: sha512-3bYs1rOD33uo8aqJfKP3JWPAibgw8Zm2+L9vBKEHJ2Rg+viTR7o5Mmv5mZcieN+FRYaAOWX5SJATX6k1PWz72g==}
+    engines: {node: '>=12'}
+
+  d3-selection@3.0.0:
+    resolution: {integrity: sha512-fmTRWbNMmsmWq6xJV8D19U/gw/bwrHfNXxrIN+HfZgnzqTHp9jOmKMhsTUjXOJnZOdZY9Q28y4yebKzqDKlxlQ==}
+    engines: {node: '>=12'}
+
+  d3-timer@3.0.1:
+    resolution: {integrity: sha512-ndfJ/JxxMd3nw31uyKoY2naivF+r29V+Lc0svZxe1JvvIRmi8hUsrMvdOwgS1o6uBHmiz91geQ0ylPP0aj1VUA==}
+    engines: {node: '>=12'}
+
+  d3-transition@3.0.1:
+    resolution: {integrity: sha512-ApKvfjsSR6tg06xrL434C0WydLr7JewBB3V+/39RMHsaXTOG0zmt/OAXeng5M5LBm0ojmxJrpomQVZ1aPvBL4w==}
+    engines: {node: '>=12'}
+    peerDependencies:
+      d3-selection: 2 - 3
+
+  d3-zoom@3.0.0:
+    resolution: {integrity: sha512-b8AmV3kfQaqWAuacbPuNbL6vahnOJflOhexLzMMNLga62+/nh0JzvJ0aO/5a5MVgUFGS7Hu1P9P03o3fJkDCyw==}
+    engines: {node: '>=12'}
 
   damerau-levenshtein@1.0.8:
     resolution: {integrity: sha512-sdQSFB7+llfUcQHUQO3+B8ERRj0Oa4w9POWMI/puGtuf7gFywGmkaLCElnudfTiKZV+NvHqL0ifzdrI8Ro7ESA==}
@@ -2816,6 +2992,12 @@ packages:
     resolution: {integrity: sha512-wS+hAgJShR0KhEvPJArfuPVN1+Hz1t0Y6n5jLrGQbkb4urgPE/0Rve+1kMB1v/oWgHgm4WIcV+i7F2pTVj+2iQ==}
     engines: {node: '>=0.10.0'}
 
+  reactflow@11.11.4:
+    resolution: {integrity: sha512-70FOtJkUWH3BAOsN+LU9lCrKoKbtOPnz2uq0CV2PLdNSwxTXOhCbsZr50GmZ+Rtw3jx8Uv7/vBFtCGixLfd4Og==}
+    peerDependencies:
+      react: '>=17'
+      react-dom: '>=17'
+
   read-cache@1.0.0:
     resolution: {integrity: sha512-Owdv/Ft7IjOgm/i0xvNDZ1LrRANRfew4b2prF3OWMQLxLfu3bS8FVhCsrSCMK4lR56Y9ya+AThoTpDCTxCmpRA==}
 
@@ -3279,6 +3461,11 @@ packages:
   url-parse@1.5.10:
     resolution: {integrity: sha512-WypcfiRhfeUP9vvF0j6rw0J3hrWrw6iZv3+22h6iRMJ/8z1Tj6XfLP4DsUix5MhMPnXpiHDoKyoZ/bdCkwBCiQ==}
 
+  use-sync-external-store@1.6.0:
+    resolution: {integrity: sha512-Pp6GSwGP/NrPIrxVFAIkOQeyw8lFenOHijQWkUTrDvrF4ALqylP2C/KCkeS9dpUM3KvYRQhna5vt7IL95+ZQ9w==}
+    peerDependencies:
+      react: ^16.8.0 || ^17.0.0 || ^18.0.0 || ^19.0.0
+
   util-deprecate@1.0.2:
     resolution: {integrity: sha512-EPD5q1uXyFxJpCrLnCc1nHnq3gOa6DZBocAIiI2TaSCA7VCJ1UJDMagCzIkXNsUYfD1daK//LTEQ8xiIbrHtcw==}
 
@@ -3430,6 +3617,21 @@ packages:
   yocto-queue@0.1.0:
     resolution: {integrity: sha512-rVksvsnNCdJ/ohGc6xgPwyN8eheCxsiLM8mxuE/t/mOVqJewPuO1miLpTHQiRgTKCLexL4MeAFVagts7HmNZ2Q==}
     engines: {node: '>=10'}
+
+  zustand@4.5.7:
+    resolution: {integrity: sha512-CHOUy7mu3lbD6o6LJLfllpjkzhHXSBlX8B9+qPddUsIfeF5S/UZ5q0kmCsnRqT1UHFQZchNFDDzMbQsuesHWlw==}
+    engines: {node: '>=12.7.0'}
+    peerDependencies:
+      '@types/react': '>=16.8'
+      immer: '>=9.0.6'
+      react: '>=16.8'
+    peerDependenciesMeta:
+      '@types/react':
+        optional: true
+      immer:
+        optional: true
+      react:
+        optional: true
 
   zwitch@2.0.4:
     resolution: {integrity: sha512-bXE4cR/kVZhKZX/RjPEflHaKVhUVl85noU3v6b8apfQEc1x4A+zBxjZ4lN8LqGd6WZ3dl98pY4o717VFmoPp+A==}
@@ -4337,6 +4539,84 @@ snapshots:
     optionalDependencies:
       '@types/react': 18.0.27
 
+  '@reactflow/background@11.3.14(@types/react@18.0.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@reactflow/core': 11.11.4(@types/react@18.0.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      classcat: 5.0.5
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      zustand: 4.5.7(@types/react@18.0.27)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@reactflow/controls@11.2.14(@types/react@18.0.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@reactflow/core': 11.11.4(@types/react@18.0.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      classcat: 5.0.5
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      zustand: 4.5.7(@types/react@18.0.27)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@reactflow/core@11.11.4(@types/react@18.0.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@types/d3': 7.4.3
+      '@types/d3-drag': 3.0.7
+      '@types/d3-selection': 3.0.11
+      '@types/d3-zoom': 3.0.8
+      classcat: 5.0.5
+      d3-drag: 3.0.0
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      zustand: 4.5.7(@types/react@18.0.27)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@reactflow/minimap@11.7.14(@types/react@18.0.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@reactflow/core': 11.11.4(@types/react@18.0.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@types/d3-selection': 3.0.11
+      '@types/d3-zoom': 3.0.8
+      classcat: 5.0.5
+      d3-selection: 3.0.0
+      d3-zoom: 3.0.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      zustand: 4.5.7(@types/react@18.0.27)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@reactflow/node-resizer@2.2.14(@types/react@18.0.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@reactflow/core': 11.11.4(@types/react@18.0.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      classcat: 5.0.5
+      d3-drag: 3.0.0
+      d3-selection: 3.0.0
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      zustand: 4.5.7(@types/react@18.0.27)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
+  '@reactflow/node-toolbar@1.3.14(@types/react@18.0.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)':
+    dependencies:
+      '@reactflow/core': 11.11.4(@types/react@18.0.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      classcat: 5.0.5
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+      zustand: 4.5.7(@types/react@18.0.27)(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
   '@rtsao/scc@1.1.0': {}
 
   '@rushstack/eslint-patch@1.12.0': {}
@@ -4460,9 +4740,128 @@ snapshots:
       tslib: 2.8.1
     optional: true
 
+  '@types/d3-array@3.2.2': {}
+
+  '@types/d3-axis@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-brush@3.0.6':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-chord@3.0.6': {}
+
+  '@types/d3-color@3.1.3': {}
+
+  '@types/d3-contour@3.0.6':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-delaunay@6.0.4': {}
+
+  '@types/d3-dispatch@3.0.7': {}
+
+  '@types/d3-drag@3.0.7':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-dsv@3.0.7': {}
+
+  '@types/d3-ease@3.0.2': {}
+
+  '@types/d3-fetch@3.0.7':
+    dependencies:
+      '@types/d3-dsv': 3.0.7
+
+  '@types/d3-force@3.0.10': {}
+
+  '@types/d3-format@3.0.4': {}
+
+  '@types/d3-geo@3.1.0':
+    dependencies:
+      '@types/geojson': 7946.0.16
+
+  '@types/d3-hierarchy@3.1.7': {}
+
+  '@types/d3-interpolate@3.0.4':
+    dependencies:
+      '@types/d3-color': 3.1.3
+
+  '@types/d3-path@3.1.1': {}
+
+  '@types/d3-polygon@3.0.2': {}
+
+  '@types/d3-quadtree@3.0.6': {}
+
+  '@types/d3-random@3.0.3': {}
+
+  '@types/d3-scale-chromatic@3.1.0': {}
+
+  '@types/d3-scale@4.0.9':
+    dependencies:
+      '@types/d3-time': 3.0.4
+
+  '@types/d3-selection@3.0.11': {}
+
+  '@types/d3-shape@3.1.8':
+    dependencies:
+      '@types/d3-path': 3.1.1
+
+  '@types/d3-time-format@4.0.3': {}
+
+  '@types/d3-time@3.0.4': {}
+
+  '@types/d3-timer@3.0.2': {}
+
+  '@types/d3-transition@3.0.9':
+    dependencies:
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3-zoom@3.0.8':
+    dependencies:
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-selection': 3.0.11
+
+  '@types/d3@7.4.3':
+    dependencies:
+      '@types/d3-array': 3.2.2
+      '@types/d3-axis': 3.0.6
+      '@types/d3-brush': 3.0.6
+      '@types/d3-chord': 3.0.6
+      '@types/d3-color': 3.1.3
+      '@types/d3-contour': 3.0.6
+      '@types/d3-delaunay': 6.0.4
+      '@types/d3-dispatch': 3.0.7
+      '@types/d3-drag': 3.0.7
+      '@types/d3-dsv': 3.0.7
+      '@types/d3-ease': 3.0.2
+      '@types/d3-fetch': 3.0.7
+      '@types/d3-force': 3.0.10
+      '@types/d3-format': 3.0.4
+      '@types/d3-geo': 3.1.0
+      '@types/d3-hierarchy': 3.1.7
+      '@types/d3-interpolate': 3.0.4
+      '@types/d3-path': 3.1.1
+      '@types/d3-polygon': 3.0.2
+      '@types/d3-quadtree': 3.0.6
+      '@types/d3-random': 3.0.3
+      '@types/d3-scale': 4.0.9
+      '@types/d3-scale-chromatic': 3.1.0
+      '@types/d3-selection': 3.0.11
+      '@types/d3-shape': 3.1.8
+      '@types/d3-time': 3.0.4
+      '@types/d3-time-format': 4.0.3
+      '@types/d3-timer': 3.0.2
+      '@types/d3-transition': 3.0.9
+      '@types/d3-zoom': 3.0.8
+
   '@types/debug@4.1.12':
     dependencies:
       '@types/ms': 2.1.0
+
+  '@types/geojson@7946.0.16': {}
 
   '@types/hast@2.3.10':
     dependencies:
@@ -4924,6 +5323,8 @@ snapshots:
     dependencies:
       clsx: 2.1.1
 
+  classcat@5.0.5: {}
+
   classnames@2.5.1: {}
 
   client-only@0.0.1: {}
@@ -5010,6 +5411,42 @@ snapshots:
       cssom: 0.3.8
 
   csstype@3.1.3: {}
+
+  d3-color@3.1.0: {}
+
+  d3-dispatch@3.0.1: {}
+
+  d3-drag@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-selection: 3.0.0
+
+  d3-ease@3.0.1: {}
+
+  d3-interpolate@3.0.1:
+    dependencies:
+      d3-color: 3.1.0
+
+  d3-selection@3.0.0: {}
+
+  d3-timer@3.0.1: {}
+
+  d3-transition@3.0.1(d3-selection@3.0.0):
+    dependencies:
+      d3-color: 3.1.0
+      d3-dispatch: 3.0.1
+      d3-ease: 3.0.1
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-timer: 3.0.1
+
+  d3-zoom@3.0.0:
+    dependencies:
+      d3-dispatch: 3.0.1
+      d3-drag: 3.0.0
+      d3-interpolate: 3.0.1
+      d3-selection: 3.0.0
+      d3-transition: 3.0.1(d3-selection@3.0.0)
 
   damerau-levenshtein@1.0.8: {}
 
@@ -6722,6 +7159,20 @@ snapshots:
     dependencies:
       loose-envify: 1.4.0
 
+  reactflow@11.11.4(@types/react@18.0.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1):
+    dependencies:
+      '@reactflow/background': 11.3.14(@types/react@18.0.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@reactflow/controls': 11.2.14(@types/react@18.0.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@reactflow/core': 11.11.4(@types/react@18.0.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@reactflow/minimap': 11.7.14(@types/react@18.0.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@reactflow/node-resizer': 2.2.14(@types/react@18.0.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      '@reactflow/node-toolbar': 1.3.14(@types/react@18.0.27)(react-dom@18.3.1(react@18.3.1))(react@18.3.1)
+      react: 18.3.1
+      react-dom: 18.3.1(react@18.3.1)
+    transitivePeerDependencies:
+      - '@types/react'
+      - immer
+
   read-cache@1.0.0:
     dependencies:
       pify: 2.3.0
@@ -7350,6 +7801,10 @@ snapshots:
       querystringify: 2.2.0
       requires-port: 1.0.0
 
+  use-sync-external-store@1.6.0(react@18.3.1):
+    dependencies:
+      react: 18.3.1
+
   util-deprecate@1.0.2: {}
 
   uvu@0.5.6:
@@ -7500,5 +7955,12 @@ snapshots:
   yaml@2.8.1: {}
 
   yocto-queue@0.1.0: {}
+
+  zustand@4.5.7(@types/react@18.0.27)(react@18.3.1):
+    dependencies:
+      use-sync-external-store: 1.6.0(react@18.3.1)
+    optionalDependencies:
+      '@types/react': 18.0.27
+      react: 18.3.1
 
   zwitch@2.0.4: {}

--- a/src/components/talks/pipeline-optimizer/deck.tsx
+++ b/src/components/talks/pipeline-optimizer/deck.tsx
@@ -1,0 +1,266 @@
+'use client';
+
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import React, { useEffect, useRef, useState } from 'react';
+import { sans } from '@/lib/fonts';
+import { slides as slidesData } from '@/components/talks/pipeline-optimizer/slides-data';
+import { SlideActsContext } from '@/components/talks/pipeline-optimizer/slide-acts-context';
+
+const CHANNEL = 'pipeline-optimizer-talk-sync';
+
+interface DeckProps {
+  children: React.ReactElement | React.ReactElement[];
+}
+
+function clampIndex(n: number, total: number): number {
+  return Math.min(Math.max(n, 0), total - 1);
+}
+
+function actsAt(index: number): number {
+  return slidesData[index]?.acts ?? 1;
+}
+
+function parseHashIndex(): number | null {
+  const match = window.location.hash.match(/^#(\d+)$/);
+  return match ? parseInt(match[1], 10) - 1 : null;
+}
+
+export function Deck({ children }: DeckProps) {
+  const slides = React.Children.toArray(children) as React.ReactElement[];
+  const total = slides.length;
+
+  const [current, setCurrent] = useState(0);
+  const [currentAct, setCurrentAct] = useState(0);
+  const [showHint, setShowHint] = useState(true);
+  const [showNotes, setShowNotes] = useState(false);
+
+  const containerRef = useRef<HTMLDivElement>(null);
+  const reducedMotion = useReducedMotion();
+
+  // Live refs — read inside the keyboard handler to avoid stale closures
+  const currentRef = useRef(0);
+  const currentActRef = useRef(0);
+  // On back-nav across a slide boundary, land on the prior slide's last act
+  const pendingActRef = useRef<number | null>(null);
+
+  // BroadcastChannel — bidirectional sync with the presenter window
+  const channelRef = useRef<BroadcastChannel | null>(null);
+  const isRemoteNavUpdate = useRef(false);
+  const isRemoteActUpdate = useRef(false);
+
+  // Lift the active slide's notes prop into the side-panel overlay
+  const activeNotes: string | undefined = (slides[current]?.props as { notes?: string })?.notes;
+  const acts = actsAt(current);
+
+  // Auto-close notes overlay when navigating to a slide without notes
+  useEffect(() => {
+    if (!activeNotes) setShowNotes(false);
+  }, [activeNotes]);
+
+  // Open BroadcastChannel once; handle nav / act / sync_request from the presenter
+  useEffect(() => {
+    if (typeof BroadcastChannel === 'undefined') return;
+    const ch = new BroadcastChannel(CHANNEL);
+    channelRef.current = ch;
+    ch.onmessage = (e: MessageEvent) => {
+      const { type, index, act } = (e.data ?? {}) as {
+        type?: string;
+        index?: number;
+        act?: number;
+      };
+      if (type === 'nav' && typeof index === 'number') {
+        isRemoteNavUpdate.current = true;
+        setCurrent(clampIndex(index, total));
+      } else if (type === 'act' && typeof act === 'number') {
+        isRemoteActUpdate.current = true;
+        setCurrentAct(act);
+      } else if (type === 'sync_request') {
+        ch.postMessage({ type: 'nav', index: currentRef.current });
+      }
+    };
+    return () => ch.close();
+  }, [total]);
+
+  // On slide change: sync ref, broadcast (unless remote), then resolve the act
+  useEffect(() => {
+    currentRef.current = current;
+    if (isRemoteNavUpdate.current) {
+      isRemoteNavUpdate.current = false;
+    } else {
+      channelRef.current?.postMessage({ type: 'nav', index: current });
+    }
+    if (pendingActRef.current !== null) {
+      setCurrentAct(pendingActRef.current);
+      pendingActRef.current = null;
+    } else {
+      setCurrentAct(0);
+    }
+  }, [current]);
+
+  // On act change: sync ref, broadcast (unless remote)
+  useEffect(() => {
+    currentActRef.current = currentAct;
+    if (isRemoteActUpdate.current) {
+      isRemoteActUpdate.current = false;
+      return;
+    }
+    channelRef.current?.postMessage({ type: 'act', act: currentAct });
+  }, [currentAct]);
+
+  // Restore slide from URL hash on mount; the hash-sync effect below canonicalises #1
+  useEffect(() => {
+    const idx = parseHashIndex();
+    if (idx !== null) setCurrent(clampIndex(idx, total));
+  }, [total]);
+
+  // Mirror the current slide to the URL hash (replaceState — back button steps slides)
+  useEffect(() => {
+    const url = new URL(window.location.href);
+    url.hash = `${current + 1}`;
+    window.history.replaceState(null, '', url.toString());
+  }, [current]);
+
+  // Browser back/forward hash navigation
+  useEffect(() => {
+    const handlePop = () => {
+      const idx = parseHashIndex();
+      if (idx !== null) setCurrent(clampIndex(idx, total));
+    };
+    window.addEventListener('popstate', handlePop);
+    return () => window.removeEventListener('popstate', handlePop);
+  }, [total]);
+
+  // Fade nav hint after 4s
+  useEffect(() => {
+    const t = setTimeout(() => setShowHint(false), 4000);
+    return () => clearTimeout(t);
+  }, []);
+
+  // Keyboard navigation
+  useEffect(() => {
+    const handleKey = (e: KeyboardEvent) => {
+      if (e.target instanceof HTMLInputElement || e.target instanceof HTMLTextAreaElement) return;
+
+      switch (e.key) {
+        case 'ArrowRight':
+        case 'ArrowDown':
+        case ' ': {
+          e.preventDefault();
+          // Advance act first; only move to next slide once all acts are exhausted
+          const totalActs = actsAt(currentRef.current);
+          if (currentActRef.current < totalActs - 1) {
+            setCurrentAct((a) => a + 1);
+          } else {
+            setCurrent((c) => Math.min(c + 1, total - 1));
+          }
+          break;
+        }
+        case 'ArrowLeft':
+        case 'ArrowUp': {
+          e.preventDefault();
+          if (currentActRef.current > 0) {
+            setCurrentAct((a) => a - 1);
+          } else if (currentRef.current > 0) {
+            // Land on the prev slide's last act
+            pendingActRef.current = actsAt(currentRef.current - 1) - 1;
+            setCurrent((c) => Math.max(c - 1, 0));
+          }
+          break;
+        }
+        case 'Escape':
+          e.preventDefault();
+          if (showNotes) {
+            setShowNotes(false);
+          } else {
+            setCurrent(0);
+            setCurrentAct(0);
+          }
+          break;
+        case 'n':
+        case 'N':
+          e.preventDefault();
+          // Silent no-op if active slide has no notes
+          if (activeNotes) setShowNotes((v) => !v);
+          break;
+        case 'f':
+        case 'F':
+          e.preventDefault();
+          if (!document.fullscreenElement) {
+            containerRef.current?.requestFullscreen().catch(() => {});
+          } else {
+            document.exitFullscreen().catch(() => {});
+          }
+          break;
+      }
+    };
+    window.addEventListener('keydown', handleKey);
+    return () => window.removeEventListener('keydown', handleKey);
+  }, [activeNotes, showNotes, total]);
+
+  return (
+    <div
+      ref={containerRef}
+      className="fixed inset-0 bg-[#282c35] flex items-center justify-center px-12 py-8"
+    >
+      {/* 16:9 outer frame — letterboxes wider/narrower screens */}
+      <div className="relative w-full aspect-video max-h-full bg-[#1c1e26] overflow-hidden">
+        <div className="absolute inset-0 flex flex-row">
+          {/* Slide column — shrinks to 65% when the notes panel is open */}
+          <div
+            className={`relative overflow-hidden h-full bg-[#1c1e26] transition-all duration-200 ease-out ${
+              showNotes && activeNotes ? 'w-[65%]' : 'w-full'
+            }`}
+          >
+            <SlideActsContext.Provider value={{ act: currentAct, totalActs: acts }}>
+              <AnimatePresence mode="wait">
+                {React.cloneElement(slides[current], { key: current })}
+              </AnimatePresence>
+            </SlideActsContext.Provider>
+
+            {/* Slide counter — appends · n · when notes exist, · act/total when acts > 1 */}
+            <div className="absolute bottom-3 right-4 font-mono text-sm text-white/40 select-none pointer-events-none z-30">
+              {current + 1} / {total}
+              {activeNotes && <span className="ml-2 opacity-60">· n ·</span>}
+              {acts > 1 && (
+                <span className="ml-2 opacity-60">· {currentAct + 1}/{acts}</span>
+              )}
+            </div>
+
+            {/* Nav hint — fades out after 4s */}
+            <div
+              className={`absolute bottom-8 left-1/2 -translate-x-1/2 font-mono text-xs text-white/30 select-none pointer-events-none z-10 transition-opacity duration-700 whitespace-nowrap ${
+                showHint ? 'opacity-100' : 'opacity-0'
+              }`}
+            >
+              ← → navigate &nbsp;·&nbsp; Space &nbsp;·&nbsp; F fullscreen
+            </div>
+          </div>
+
+          {/* Speaker notes side panel — fills the remaining 35% when active */}
+          <AnimatePresence>
+            {showNotes && activeNotes && (
+              <motion.div
+                role="region"
+                aria-live="polite"
+                aria-label="Speaker notes"
+                className={`flex-1 h-full bg-[#1a1d25] border-l border-white/10 p-10 overflow-y-auto z-20 ${sans.className}`}
+                initial={{ opacity: 0 }}
+                animate={{ opacity: 1 }}
+                exit={{ opacity: 0 }}
+                transition={{ duration: reducedMotion ? 0 : 0.15, ease: 'easeOut' }}
+                onClick={(e) => e.stopPropagation()}
+              >
+                <p className="font-mono text-xs text-white/40 uppercase tracking-wider mb-6">
+                  Speaker notes
+                </p>
+                <p className="text-base leading-relaxed text-white/85 whitespace-pre-wrap">
+                  {activeNotes}
+                </p>
+              </motion.div>
+            )}
+          </AnimatePresence>
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/src/components/talks/pipeline-optimizer/funnel-animation.tsx
+++ b/src/components/talks/pipeline-optimizer/funnel-animation.tsx
@@ -1,0 +1,763 @@
+'use client';
+
+import { AnimatePresence, motion, useReducedMotion } from 'framer-motion';
+import React, { useCallback, useEffect, useRef, useState } from 'react';
+import { useSlideActs } from './slide-acts-context';
+
+// ─── Counts (TODO: swap from research/05-impact.md) ──────────────────────────
+const C = { scanned: 120, violations: 50, changes: 40, approved: 40, prs: 40 } as const;
+
+// ─── Brand tokens ────────────────────────────────────────────────────────────
+const GREEN    = 'rgb(0, 175, 154)';
+const PINK     = 'rgb(255, 167, 196)';
+const GREEN_85 = 'rgba(0,175,154,0.85)';
+const PINK_85  = 'rgba(255,167,196,0.85)';
+
+// ─── Motion tokens ───────────────────────────────────────────────────────────
+const EASE: [number, number, number, number] = [0.23, 1, 0.32, 1];
+const SPRING_LAYOUT = { type: 'spring' as const, stiffness: 220, damping: 24 };
+const SPRING_POP    = { type: 'spring' as const, stiffness: 380, damping: 22 };
+
+const wait = (ms: number) => new Promise<void>((r) => setTimeout(r, ms));
+
+// ─── Types ───────────────────────────────────────────────────────────────────
+type Verdict  = 'none' | 'approved' | 'retrying' | 'rejected';
+type ItemLane = 'pre' | 'impl' | 'review' | 'pr';
+
+interface FunnelItem {
+  id:           number;
+  lane:         ItemLane;
+  dropped:      boolean;
+  showProgress: boolean;
+  progressDone: boolean;
+  verdict:      Verdict;
+}
+
+const TOTAL     = 15;
+const SURVIVORS = new Set([0, 1, 2, 3, 4, 5]);
+
+function makeAllPre(): FunnelItem[] {
+  return Array.from({ length: TOTAL }, (_, id): FunnelItem => ({
+    id, lane: 'pre', dropped: false,
+    showProgress: false, progressDone: false, verdict: 'none',
+  }));
+}
+
+// ─── Act snapshots ───────────────────────────────────────────────────────────
+interface AnimState {
+  items:      FunnelItem[];
+  arrows:     { preToImpl: boolean; reviewToPr: boolean };
+  counters:   { pre: string; impl: string; review: string; pr: string };
+  laneActive: { pre: boolean; impl: boolean; review: boolean; pr: boolean };
+}
+
+function stateForAct(act: number): AnimState {
+  const s: AnimState = {
+    items:      [],
+    arrows:     { preToImpl: false, reviewToPr: false },
+    counters:   { pre: '', impl: '', review: '', pr: '' },
+    laneActive: { pre: false, impl: false, review: false, pr: false },
+  };
+  if (act === 0) return s;
+
+  s.items = makeAllPre();
+  s.counters.pre = `${C.scanned} scanned`;
+  s.laneActive.pre = true;
+  if (act === 1) return s;
+
+  s.items = s.items.map((item): FunnelItem => ({
+    ...item,
+    lane:    SURVIVORS.has(item.id) ? 'impl' : 'pre',
+    dropped: !SURVIVORS.has(item.id),
+  }));
+  s.arrows.preToImpl = true;
+  s.counters.pre = `${C.violations} violations`;
+  s.laneActive = { pre: false, impl: true, review: false, pr: false };
+  if (act === 2) return s;
+
+  s.items = s.items.map((item): FunnelItem => ({
+    ...item,
+    showProgress: item.lane === 'impl',
+    progressDone: item.lane === 'impl',
+  }));
+  s.counters.impl = `${C.changes} changes implemented and reviewed`;
+  s.counters.review = '';
+  s.laneActive = { pre: false, impl: true, review: true, pr: false };
+  if (act === 3) return s;
+
+  s.items = [
+    ...Array.from({ length: 5 }, (_, i): FunnelItem => ({
+      id: i, lane: 'pr', dropped: false,
+      showProgress: false, progressDone: true, verdict: 'approved',
+    })),
+    {
+      id: 5, lane: 'review', dropped: true,
+      showProgress: false, progressDone: false, verdict: 'rejected',
+    },
+    ...Array.from({ length: 9 }, (_, i): FunnelItem => ({
+      id: i + 6, lane: 'pre', dropped: true,
+      showProgress: false, progressDone: false, verdict: 'none',
+    })),
+  ];
+  s.counters.review = '';
+  s.laneActive = { pre: false, impl: false, review: false, pr: true };
+  if (act === 4) return s;
+
+  s.arrows.reviewToPr = true;
+  s.counters.pr = `${C.prs} PRs`;
+  return s;
+}
+
+// ─── VerdictGlyph — popping symbol in top-right of an item ───────────────────
+function VerdictGlyph({ verdict }: { verdict: Exclude<Verdict, 'none'> }) {
+  let symbol: string;
+  let style: React.CSSProperties | undefined;
+  let extraClass = '';
+  switch (verdict) {
+    case 'approved':
+      symbol = '✓';
+      style = { color: GREEN };
+      break;
+    case 'retrying':
+      symbol = '↺';
+      style = { color: PINK };
+      break;
+    case 'rejected':
+      symbol = '✕';
+      extraClass = 'text-red-400';
+      break;
+  }
+  return (
+    <motion.span
+      initial={{ opacity: 0, scale: 0 }}
+      animate={{ opacity: 1, scale: 1 }}
+      transition={SPRING_POP}
+      className={`absolute top-1 right-1.5 text-[12px] font-bold leading-none ${extraClass}`}
+      style={style}
+    >
+      {symbol}
+    </motion.span>
+  );
+}
+
+// ─── ItemDot ─────────────────────────────────────────────────────────────────
+function ItemDot({ item, staggerIdx }: { item: FunnelItem; staggerIdx: number }) {
+  const isPr      = item.lane === 'pr';
+  const isDropped = item.dropped;
+  const delay     = staggerIdx * 0.055;
+  // approved verdict is implied by the pink PR pill — hide the ✓ in that lane
+  const showVerdict = item.verdict !== 'none' && !(item.verdict === 'approved' && isPr);
+
+  return (
+    <motion.div
+      layoutId={`fi-${item.id}`}
+      layout
+      className="relative flex-shrink-0 overflow-hidden"
+      style={{ width: 72, height: 32, borderRadius: 6 }}
+      initial={{ opacity: 0, y: -16, scale: 0.88 }}
+      animate={{
+        backgroundColor: isPr
+          ? 'rgba(255,167,196,0.85)'
+          : isDropped ? 'rgba(255,255,255,0.04)' : 'rgba(54,60,72,0.9)',
+        borderColor: isPr ? 'rgba(255,167,196,0.55)' : 'rgba(255,255,255,0.30)',
+        borderWidth: 1, borderStyle: 'solid',
+        opacity: isDropped ? 0.22 : 1,
+        y: isDropped ? 5 : 0,
+        scale: 1,
+      }}
+      exit={{ opacity: 0, y: 32, scale: 0.88, transition: { duration: 0.22, ease: EASE } }}
+      transition={{
+        layout:          SPRING_LAYOUT,
+        opacity:         { duration: 0.28, delay },
+        scale:           { ...SPRING_POP, delay },
+        y:               { type: 'spring', stiffness: 260, damping: 22, delay },
+        backgroundColor: { duration: 0.22 },
+        borderColor:     { duration: 0.22 },
+      }}
+    >
+      {item.showProgress && (
+        <motion.div
+          className="absolute bottom-0 left-0 h-[3px] w-full"
+          style={{ backgroundColor: GREEN, transformOrigin: 'left', borderRadius: '0 0 6px 6px' }}
+          initial={{ scaleX: 0 }}
+          animate={{ scaleX: item.progressDone ? 1 : 0 }}
+          transition={{ duration: 0.52, ease: [0.35, 0, 0.25, 1], delay: (item.id % 6) * 0.06 }}
+        />
+      )}
+      {showVerdict && <VerdictGlyph verdict={item.verdict as Exclude<Verdict, 'none'>} />}
+    </motion.div>
+  );
+}
+
+// ─── ScanLine ────────────────────────────────────────────────────────────────
+function ScanLine({ visible }: { visible: boolean }) {
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          className="absolute left-0 right-0 z-10 pointer-events-none"
+          style={{ height: 2, backgroundColor: GREEN }}
+          initial={{ y: 0, opacity: 0 }}
+          animate={{ y: 180, opacity: 0.85 }}
+          exit={{ opacity: 0 }}
+          transition={{ duration: 0.52, ease: 'linear' }}
+        />
+      )}
+    </AnimatePresence>
+  );
+}
+
+// ─── PinkPulse — single dramatic pulse at PR exit ────────────────────────────
+function PinkPulse({ visible }: { visible: boolean }) {
+  return (
+    <AnimatePresence>
+      {visible && (
+        <motion.div
+          className="absolute inset-0 pointer-events-none z-20"
+          style={{ backgroundColor: PINK, borderRadius: 8 }}
+          initial={{ opacity: 0.45, scale: 0.88 }}
+          animate={{ opacity: 0, scale: 2.4 }}
+          exit={{}}
+          transition={{ duration: 0.65, ease: EASE }}
+        />
+      )}
+    </AnimatePresence>
+  );
+}
+
+// ─── ModelPill ───────────────────────────────────────────────────────────────
+function ModelPill({ model }: { model: 'Haiku' | 'Sonnet' }) {
+  const color = model === 'Haiku' ? GREEN : PINK;
+  return (
+    <span
+      className="rounded-full font-mono px-2 py-0.5 flex-shrink-0"
+      style={{ fontSize: 11, lineHeight: 1.6, border: `1px solid ${color}`, color }}
+    >
+      {model}
+    </span>
+  );
+}
+
+// ─── ToolDots ────────────────────────────────────────────────────────────────
+// Dots = tools/integrations per stage. REVIEWER = ∅ (no MCP). PR = 👤 (human).
+function ToolDots({ count, isEmpty, isHuman }: { count?: number; isEmpty?: boolean; isHuman?: boolean }) {
+  if (isHuman) {
+    return <span style={{ fontSize: 15, lineHeight: 1, color: PINK }}>👤</span>;
+  }
+  if (isEmpty) {
+    return <span style={{ fontSize: 16, color: 'rgba(255,255,255,0.38)', lineHeight: 1 }}>∅</span>;
+  }
+  return (
+    <div className="flex items-center gap-1">
+      {Array.from({ length: count ?? 0 }, (_, i) => (
+        <div key={i} style={{
+          width: 10, height: 10, borderRadius: 2,
+          backgroundColor: 'rgba(255,255,255,0.55)', flexShrink: 0,
+        }} />
+      ))}
+    </div>
+  );
+}
+
+// ─── ForwardArrow (animated path-draw) ───────────────────────────────────────
+function ForwardArrow({ active, color = 'rgba(255,255,255,0.8)' }: { active: boolean; color?: string }) {
+  return (
+    <div style={{
+      flexShrink: 0, width: 26,
+      display: 'flex', flexDirection: 'column',
+      alignItems: 'center', justifyContent: 'flex-start', paddingTop: 96,
+    }}>
+      <svg width="26" height="14" viewBox="0 0 26 14" fill="none" style={{ overflow: 'visible' }}>
+        <motion.path
+          d="M0 7 H18 M13 3 L23 7 L13 11"
+          stroke={color} strokeWidth={2} strokeLinecap="round" strokeLinejoin="round"
+          initial={{ pathLength: 0, opacity: 0 }}
+          animate={{ pathLength: active ? 1 : 0, opacity: active ? 1 : 0 }}
+          transition={{ duration: 0.5, ease: [0.35, 0, 0.25, 1] }}
+        />
+      </svg>
+    </div>
+  );
+}
+
+// ─── LoopArcs — closed oval loop between IMPL and REVIEWER ──────────────────
+// Top half  (IMPL→REVIEWER): solid teal,  arrowhead at REVIEWER (right) end.
+// Bottom half (REVIEWER→IMPL): dashed pink, arrowhead at IMPL (left) end.
+// Single closed ellipse reads as a cycle, not two separate U shapes.
+// Extends via overflow:visible into the lane bodies above the SVG element.
+function LoopArcs() {
+  const cx = 21;         // center of 42px column
+  const lx = cx - 152;  // left connection (IMPL side)
+  const rx = cx + 152;  // right connection (REVIEWER side)
+  const cy = -260;       // oval center y — negative = above SVG origin (mid-lane)
+  const oa = 152;        // horizontal semi-axis (half the lane-to-lane span)
+  const ob = 90;         // vertical semi-axis → 304×180px oval, ~1.7:1 aspect
+
+  const TEAL     = GREEN;
+  const PINK_ARC = PINK;
+
+  return (
+    <div style={{
+      flexShrink: 0, width: 42, alignSelf: 'stretch',
+      display: 'flex', alignItems: 'flex-end',
+      paddingBottom: 28,
+    }}>
+      <svg width={42} height={55} fill="none" style={{ overflow: 'visible' }}>
+
+        {/* Top half: IMPL → REVIEWER — solid teal, sweeps over the top */}
+        <path
+          d={`M ${lx},${cy} A ${oa},${ob},0,0,1,${rx},${cy}`}
+          stroke={TEAL} strokeWidth={1.8} strokeLinecap="round" fill="none"
+        />
+        {/* Arrowhead at REVIEWER (right) — tip at connection point, opens upward */}
+        <path
+          d={`M ${rx-7},${cy-10} L ${rx},${cy} L ${rx+7},${cy-10}`}
+          stroke={TEAL} strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round" fill="none"
+        />
+
+        {/* Bottom half: REVIEWER → IMPL — dashed pink, sweeps under */}
+        <path
+          d={`M ${rx},${cy} A ${oa},${ob},0,0,1,${lx},${cy}`}
+          stroke={PINK_ARC} strokeWidth={1.8} strokeLinecap="round" strokeDasharray="6 4" fill="none"
+        />
+        {/* Arrowhead at IMPL (left) — tip at connection point, opens downward */}
+        <path
+          d={`M ${lx-7},${cy+10} L ${lx},${cy} L ${lx+7},${cy+10}`}
+          stroke={PINK_ARC} strokeWidth={1.8} strokeLinecap="round" strokeLinejoin="round" fill="none"
+        />
+
+        {/* "⟲ 2×" at oval center */}
+        <text
+          x={cx} y={cy + 4}
+          textAnchor="middle" fontSize="9"
+          fontFamily="ui-monospace,monospace" fill="rgba(255,255,255,0.55)"
+        >⟲ 2×</text>
+
+      </svg>
+    </div>
+  );
+}
+
+// ─── useArrivalGlow — briefly flashes when `active` flips false→true ─────────
+function useArrivalGlow(active: boolean): boolean {
+  const [glowing, setGlowing] = useState(false);
+  const wasActive = useRef(false);
+  useEffect(() => {
+    if (active && !wasActive.current) {
+      setGlowing(true);
+      wasActive.current = true;
+      const t = window.setTimeout(() => setGlowing(false), 650);
+      return () => window.clearTimeout(t);
+    }
+    if (!active) wasActive.current = false;
+  }, [active]);
+  return glowing;
+}
+
+// ─── LanePanel ───────────────────────────────────────────────────────────────
+interface LanePanelProps {
+  label:          string;
+  subLabel?:      string;
+  model?:         'Haiku' | 'Sonnet';
+  toolCount?:     number;
+  toolsEmpty?:    boolean;
+  toolsHuman?:    boolean;
+  stageColor:     string;
+  active:         boolean;
+  counter:        string;
+  counterBright?: boolean;
+  showScanLine?:  boolean;
+  showPulse?:     boolean;
+  /** Narrow fixed-width column — used for output zones like PR OPENED */
+  compact?:       boolean;
+  /** Suppress the built-in bottom counter (used when a merged counter is rendered outside) */
+  hideCounter?:   boolean;
+  /** Force border-right even when last child (prevents last:border-r-0 from removing it) */
+  forceBorderRight?: boolean;
+  children:       React.ReactNode;
+}
+
+function LanePanel({
+  label, subLabel, model, toolCount, toolsEmpty, toolsHuman,
+  stageColor, active, counter, counterBright = false,
+  showScanLine = false, showPulse = false, compact = false,
+  hideCounter = false, forceBorderRight = false,
+  children,
+}: LanePanelProps) {
+  const glowing = useArrivalGlow(active);
+
+  const counterColor = counterBright
+    ? stageColor
+    : active
+      ? 'rgba(255,255,255,1.0)'
+      : 'rgba(255,255,255,0.22)';
+
+  return (
+    <div
+      className={`min-w-0 flex flex-col p-5 gap-3 border-r border-white/[0.07] ${forceBorderRight ? '' : 'last:border-r-0'} relative overflow-hidden`}
+      style={compact ? { flex: '0 0 192px', borderLeft: '1px dashed rgba(255,167,196,0.25)' } : { flex: '1 1 0' }}
+    >
+
+      {/* Lane arrival glow */}
+      <AnimatePresence>
+        {glowing && (
+          <motion.div
+            className="absolute inset-0 pointer-events-none"
+            initial={{ opacity: 0.18 }}
+            animate={{ opacity: 0 }}
+            exit={{ opacity: 0 }}
+            transition={{ duration: 0.65, ease: 'easeOut' }}
+            style={{ backgroundColor: stageColor }}
+          />
+        )}
+      </AnimatePresence>
+
+      {/* Chrome: label, model pill, turn cap, tool dots */}
+      <div className="relative flex-shrink-0 space-y-2 z-10">
+        <div
+          className="font-mono font-bold uppercase tracking-wide leading-none"
+          style={{ fontSize: 22, color: stageColor }}
+        >
+          {label}
+        </div>
+        {subLabel && (
+          <div
+            className="font-mono leading-none"
+            style={{ fontSize: 11, color: 'rgba(255,255,255,0.55)', marginTop: 4 }}
+          >
+            {subLabel}
+          </div>
+        )}
+        <div className="flex items-center gap-2 flex-wrap min-h-[20px]">
+          {model && <ModelPill model={model} />}
+        </div>
+        <div className="flex items-center" style={{ height: 16 }}>
+          <ToolDots count={toolCount} isEmpty={toolsEmpty} isHuman={toolsHuman} />
+        </div>
+      </div>
+
+      {/* Items track */}
+      <div className="relative flex-1 overflow-hidden min-h-0 z-10">
+        <ScanLine visible={showScanLine} />
+        <PinkPulse visible={showPulse} />
+        <div className="flex flex-wrap content-start gap-2">{children}</div>
+      </div>
+
+      {/* Counter — ticks on change via key remount */}
+      {!hideCounter && (
+        <AnimatePresence mode="wait">
+          <motion.div
+            key={counter || 'zero'}
+            className="relative font-mono font-semibold flex-shrink-0 leading-none z-10"
+            initial={{ opacity: 0, y: 8 }}
+            animate={{ opacity: 1, y: 0 }}
+            exit={{ opacity: 0, y: -8 }}
+            transition={{ duration: 0.28, ease: EASE }}
+            style={{ fontSize: 20, color: counterColor }}
+          >
+            {counter || '0'}
+          </motion.div>
+        </AnimatePresence>
+      )}
+    </div>
+  );
+}
+
+// ─── FunnelAnimation ─────────────────────────────────────────────────────────
+function FunnelAnimation() {
+  const reduced = useReducedMotion();
+  const mounted = useRef(true);
+  const lastAct = useRef(0);
+
+  const { act } = useSlideActs();
+  const [items,        setItems]        = useState<FunnelItem[]>([]);
+  const [showScanLine, setShowScanLine] = useState(false);
+  const [arrows,       setArrows]       = useState({ preToImpl: false, reviewToPr: false });
+  const [counters,     setCounters]     = useState({ pre: '', impl: '', review: '', pr: '' });
+  const [laneActive,   setLaneActive]   = useState({ pre: false, impl: false, review: false, pr: false });
+  const [showPulse,    setShowPulse]    = useState(false);
+
+  useEffect(() => {
+    mounted.current = true;
+    return () => { mounted.current = false; };
+  }, []);
+
+  // Reduced motion: snap to final act on mount
+  useEffect(() => {
+    if (!reduced) return;
+    const s = stateForAct(5);
+    setItems(s.items);
+    setArrows(s.arrows);
+    setCounters(s.counters);
+    setLaneActive(s.laneActive);
+    lastAct.current = 5;
+  }, [reduced]);
+
+  // Snap to act state instantly (backward / reset)
+  const snapToAct = useCallback((n: number) => {
+    const s = stateForAct(n);
+    setItems(s.items);
+    setShowScanLine(false);
+    setArrows(s.arrows);
+    setCounters(s.counters);
+    setLaneActive(s.laneActive);
+    setShowPulse(false);
+  }, []);
+
+  // Per-act async animation
+  const runAct = useCallback(async (n: number) => {
+    if (!mounted.current) return;
+
+    const patchAll = (compute: (i: FunnelItem) => Partial<FunnelItem>) =>
+      setItems(prev => prev.map(i => ({ ...i, ...compute(i) })));
+
+    if (n === 1) {
+      setItems(makeAllPre());
+      setLaneActive(l => ({ ...l, pre: true }));
+      await wait(1500);
+      if (!mounted.current) return;
+      setCounters(c => ({ ...c, pre: `${C.scanned} scanned` }));
+
+    } else if (n === 2) {
+      setShowScanLine(true);
+      await wait(550);
+      if (!mounted.current) return;
+      setShowScanLine(false);
+      patchAll(i => ({ dropped: !SURVIVORS.has(i.id) }));
+      await wait(380);
+      setCounters(c => ({ ...c, pre: `${C.violations} violations` }));
+      await wait(320);
+      setArrows(a => ({ ...a, preToImpl: true }));
+      await wait(350);
+      patchAll(i => ({ lane: SURVIVORS.has(i.id) ? 'impl' : 'pre' }));
+      setLaneActive({ pre: false, impl: true, review: false, pr: false });
+
+    } else if (n === 3) {
+      patchAll(i => ({ showProgress: i.lane === 'impl' }));
+      setLaneActive(l => ({ ...l, review: true }));
+      await wait(160);
+      patchAll(i => ({ progressDone: i.lane === 'impl' }));
+      await wait(900);
+      if (!mounted.current) return;
+      setCounters(c => ({ ...c, impl: `${C.changes} changes implemented and reviewed` }));
+
+    } else if (n === 4) {
+      // Batch: all impl items jump to review
+      patchAll(i => ({
+        lane: i.lane === 'impl' ? 'review' : i.lane,
+        showProgress: false, progressDone: false,
+      }));
+      setLaneActive(l => ({ ...l, impl: false }));
+      await wait(280);
+      if (!mounted.current) return;
+
+      // Batch verdict: survivors approved, item 5 rejected
+      patchAll(i => {
+        if (i.lane !== 'review') return {};
+        return i.id === 5
+          ? { verdict: 'rejected', dropped: true }
+          : { verdict: 'approved' };
+      });
+      await wait(220);
+      if (!mounted.current) return;
+
+      // Batch: approved items → PR
+      patchAll(i =>
+        i.lane === 'review' && i.verdict === 'approved' ? { lane: 'pr' as ItemLane } : {}
+      );
+      await wait(350);
+      if (!mounted.current) return;
+      setLaneActive(l => ({ ...l, review: false, pr: true }));
+
+    } else if (n === 5) {
+      setArrows(a => ({ ...a, reviewToPr: true }));
+      await wait(380);
+      setCounters(c => ({ ...c, pr: `${C.prs} PRs` }));
+      await wait(400);
+      setShowPulse(true);
+      await wait(700);
+      if (!mounted.current) return;
+      setShowPulse(false);
+      setLaneActive({ pre: false, impl: false, review: false, pr: true });
+    }
+  }, []);
+
+  // Act transition: forward → animate, backward → snap
+  useEffect(() => {
+    if (reduced) return;
+    if (act > lastAct.current) {
+      lastAct.current = act;
+      runAct(act);
+    } else if (act < lastAct.current) {
+      lastAct.current = act;
+      snapToAct(act);
+    }
+  }, [act, reduced, runAct, snapToAct]);
+
+  // Deck owns all navigation — act comes from SlideActsContext via useSlideActs().
+
+  // Lane slices
+  const preItems  = items.filter(i => i.lane === 'pre');
+  const implItems = items.filter(i => i.lane === 'impl');
+  const revItems  = items.filter(i => i.lane === 'review');
+  const prItems   = items.filter(i => i.lane === 'pr');
+
+  return (
+    <div className="w-full h-full flex flex-col overflow-hidden select-none">
+      {/* 4-lane row */}
+      <div className="relative flex flex-row flex-1 overflow-hidden">
+
+        {/* ── Funnel cone: narrows Pre-screen → Impl → Reviewer ───────────────
+            PR Open lives OUTSIDE this cone (right 25% of row, after the Reviewer).
+            75% ≈ (3 flex-1 lanes + 26px arrow + 42px loop-arcs) / total row width. */}
+        <svg
+          aria-hidden="true"
+          style={{
+            position: 'absolute', left: 0, top: 0,
+            width: '75%', height: '100%',
+            pointerEvents: 'none',
+          }}
+          viewBox="0 0 100 100"
+          preserveAspectRatio="none"
+        >
+          {/* Interior teal tint */}
+          <path
+            d="M 0,10 L 100,30 L 100,70 L 0,90 Z"
+            fill="rgba(0,175,154,0.05)"
+            vectorEffect="non-scaling-stroke"
+          />
+          {/* Top converging edge */}
+          <line x1="0" y1="10" x2="100" y2="30"
+            stroke="rgba(0,175,154,0.22)" strokeWidth="1.5" strokeLinecap="round"
+            vectorEffect="non-scaling-stroke" />
+          {/* Bottom converging edge */}
+          <line x1="0" y1="90" x2="100" y2="70"
+            stroke="rgba(0,175,154,0.22)" strokeWidth="1.5" strokeLinecap="round"
+            vectorEffect="non-scaling-stroke" />
+          {/* Narrow-end closing line (Reviewer right edge) */}
+          <line x1="100" y1="30" x2="100" y2="70"
+            stroke="rgba(0,175,154,0.22)" strokeWidth="1.5" strokeLinecap="round"
+            vectorEffect="non-scaling-stroke" />
+        </svg>
+
+        <LanePanel
+          label="PRE-SCREEN"
+          subLabel="scans every repo × every playbook"
+          model="Haiku"
+          toolCount={2}
+          stageColor={GREEN_85}
+          active={laneActive.pre}
+          counter={counters.pre}
+          showScanLine={showScanLine}
+        >
+          <AnimatePresence>
+            {preItems.map((item, idx) => (
+              <ItemDot key={item.id} item={item} staggerIdx={idx} />
+            ))}
+          </AnimatePresence>
+        </LanePanel>
+
+        <ForwardArrow active={arrows.preToImpl} color={GREEN} />
+
+        {/* IMPL + LoopArcs + REVIEWER column group — shared merged counter at bottom */}
+        <div style={{ flex: '2 2 0', display: 'flex', flexDirection: 'column', minWidth: 0 }}>
+          <div style={{ flex: '1 1 0', display: 'flex', flexDirection: 'row', overflow: 'hidden', minHeight: 0 }}>
+            <LanePanel
+              label="IMPLEMENTATION"
+              model="Sonnet"
+              toolCount={4}
+              stageColor={GREEN}
+              active={laneActive.impl}
+              counter={counters.impl}
+              hideCounter
+            >
+              <AnimatePresence>
+                {implItems.map((item, idx) => (
+                  <ItemDot key={item.id} item={item} staggerIdx={idx} />
+                ))}
+              </AnimatePresence>
+            </LanePanel>
+
+            {/* Loop arcs — static chrome, visible from Act 0 */}
+            <LoopArcs />
+
+            <LanePanel
+              label="REVIEWER"
+              model="Haiku"
+              toolsEmpty
+              stageColor={PINK_85}
+              active={laneActive.review}
+              counter={counters.review}
+              hideCounter
+              forceBorderRight
+            >
+              <AnimatePresence>
+                {revItems.map((item, idx) => (
+                  <ItemDot key={item.id} item={item} staggerIdx={idx} />
+                ))}
+              </AnimatePresence>
+            </LanePanel>
+          </div>
+
+          {/* Merged counter spanning IMPL + REVIEWER width */}
+          <AnimatePresence mode="wait">
+            <motion.div
+              key={counters.impl || 'zero'}
+              className="flex-shrink-0 font-mono font-semibold leading-none px-5 pb-5 pt-3"
+              initial={{ opacity: 0, y: 8 }}
+              animate={{ opacity: 1, y: 0 }}
+              exit={{ opacity: 0, y: -8 }}
+              transition={{ duration: 0.28, ease: EASE }}
+              style={{
+                fontSize: 20,
+                color: (laneActive.impl || laneActive.review) ? 'rgba(255,255,255,1.0)' : 'rgba(255,255,255,0.22)',
+              }}
+            >
+              {counters.impl ? (
+                <>
+                  {counters.impl}{' '}
+                  <span style={{ color: GREEN }}>&#x2713;</span>
+                </>
+              ) : '0'}
+            </motion.div>
+          </AnimatePresence>
+        </div>
+
+        <ForwardArrow active={arrows.reviewToPr} color={PINK} />
+
+        <LanePanel
+          label="PR OPENED"
+          subLabel="output"
+          toolsHuman
+          stageColor={PINK}
+          active={laneActive.pr}
+          counter={counters.pr}
+          counterBright
+          showPulse={showPulse}
+          compact
+        >
+          <AnimatePresence>
+            {prItems.map((item, idx) => (
+              <ItemDot key={item.id} item={item} staggerIdx={idx} />
+            ))}
+          </AnimatePresence>
+        </LanePanel>
+      </div>
+
+      {/* Bottom bar — act progress indicator */}
+      <div className="flex-shrink-0 flex items-center justify-end px-5 py-2">
+        {act > 0 && act < 5 && (
+          <div
+            className="font-mono text-xs pointer-events-none"
+            style={{ color: 'rgba(255,255,255,0.38)' }}
+          >
+            {act}/5
+          </div>
+        )}
+      </div>
+    </div>
+  );
+}
+
+export default FunnelAnimation;
+export { FunnelAnimation };

--- a/src/components/talks/pipeline-optimizer/slide-acts-context.tsx
+++ b/src/components/talks/pipeline-optimizer/slide-acts-context.tsx
@@ -1,0 +1,16 @@
+'use client';
+
+import { createContext, useContext } from 'react';
+
+export interface SlideActsValue {
+  /** Current act, 0-indexed. */
+  act: number;
+  /** Total acts on the active slide (1 if no animation). */
+  totalActs: number;
+}
+
+export const SlideActsContext = createContext<SlideActsValue>({ act: 0, totalActs: 1 });
+
+export function useSlideActs(): SlideActsValue {
+  return useContext(SlideActsContext);
+}

--- a/src/components/talks/pipeline-optimizer/slide.tsx
+++ b/src/components/talks/pipeline-optimizer/slide.tsx
@@ -1,0 +1,39 @@
+'use client';
+
+import { motion, useReducedMotion } from 'framer-motion';
+import { sans } from '@/lib/fonts';
+
+export interface SlideProps {
+  title?: string | null;
+  /** Speaker notes — read by <Deck> to render the side-panel overlay; not rendered inline. */
+  notes?: string;
+  /** When true, removes the default p-4 padding so content can bleed to the slide edges. */
+  fullBleed?: boolean;
+  children?: React.ReactNode;
+}
+
+export function Slide({ title, children, fullBleed }: SlideProps) {
+  const reduced = useReducedMotion();
+
+  return (
+    <motion.div
+      className={`absolute inset-0 flex flex-col ${fullBleed ? '' : 'px-12 pt-14 pb-8'} ${sans.className}`}
+      initial={{ opacity: 0, y: reduced ? 0 : 8 }}
+      animate={{ opacity: 1, y: 0 }}
+      exit={{ opacity: 0, y: reduced ? 0 : -8 }}
+      transition={{ duration: reduced ? 0.1 : 0.25, ease: 'easeOut' }}
+    >
+      {title && (
+        <div
+          className={`${sans.className} text-lg uppercase tracking-widest mb-4`}
+          style={{ color: 'rgb(0,175,154)' }}
+        >
+          {title}
+        </div>
+      )}
+      <div className="flex-1 flex flex-col justify-center">
+        {children}
+      </div>
+    </motion.div>
+  );
+}

--- a/src/components/talks/pipeline-optimizer/slides-data.tsx
+++ b/src/components/talks/pipeline-optimizer/slides-data.tsx
@@ -1,0 +1,116 @@
+/**
+ * slides-data.tsx — deck assembler.
+ *
+ * Imports per-section slide arrays and merges them into a single ordered list.
+ * Each section file lives in slides/<N>-<topic>.tsx and exports a SlideData[].
+ *
+ * To add or edit a slide: open the corresponding section file.
+ * To add a new section: create the file, import it here, and spread it in order.
+ */
+
+'use client';
+
+import React from 'react';
+import { sans } from '@/lib/fonts';
+import type { SlideData } from './slides/_types';
+
+import whatWeBuilt from './slides/00b-what-we-built';
+import hook from './slides/01-hook';
+import naive from './slides/03-naive';
+import { archMap, funnel } from './slides/04-architecture';
+import playbookSlides from './slides/04c-playbooks';
+import feedbackLoopSlides from './slides/06b-feedback-loop';
+import whyCi from './slides/04b-why-ci';
+import vsAlternatives from './slides/04d-vs-alternatives';
+import keyInsight from './slides/05-key-insight';
+import results from './slides/07-results';
+import lessons from './slides/08-lessons';
+import close from './slides/09-close';
+
+// Re-export SlideData so page.tsx can import it from a single path if needed.
+export type { SlideData };
+
+// ── Slide 01 — Title card (full-bleed, owned by assembler) ──────────────────
+// TODO(slide-designer): Full-bleed, centered, large mono title, dot-grid background (static),
+//   fade-in title 400ms then byline 600ms offset. Bookend aesthetic — identical to slide 19.
+const titleSlide: SlideData = {
+  id: 1,
+  title: undefined,
+  acts: 1,
+  content: (
+    // `absolute inset-0` escapes <Slide>'s p-12 for full-bleed effect.
+    <div className="absolute inset-0 flex flex-col items-center justify-center text-center px-12">
+      <h1 className={`${sans.className} text-6xl md:text-7xl font-bold text-white mb-8`}>
+        Replace Yourself with Agents
+      </h1>
+      <p className={`${sans.className} text-lg md:text-xl font-mono text-white/50 mb-16 tracking-wide`}>
+        trust · confidence thresholds · the agent that became better at my job
+      </p>
+      <div className="font-mono text-sm text-white/40 flex flex-col gap-1">
+        <div>Tulsi Sapkota</div>
+        <div>Senior Software Engineer @ Linktree</div>
+      </div>
+    </div>
+  ),
+  notes:
+    'How we built an agent that monitors our Buildkite pipelines, reasons about inefficiencies, and raises PRs to fix it. A practical story about trust, confidence thresholds, and what happens when the agent is better at your job than you are.\n\nThe synopsis lives in speaker notes — slide face shows only the compressed tagline.',
+};
+
+// ── Full-bleed transforms ────────────────────────────────────────────────────
+// page.tsx renders <Slide title={s.title} notes={s.notes}>{s.content}</Slide>
+// and doesn't forward a fullBleed prop. As a workaround, we embed an
+// `absolute inset-0` wrapper directly in the content so slides can escape the
+// <Slide> p-12 padding without editing deck.tsx or page.tsx.
+
+/** Slides 4 & 7: pull the title into the content, wrap everything absolute. */
+function withInlineTitle(s: SlideData): SlideData {
+  if (s.id !== 4 && s.id !== 7) return s;
+  const savedTitle = s.title;
+  return {
+    ...s,
+    title: undefined,
+    content: (
+      <div className={`${sans.className} absolute inset-0 flex flex-col px-12 pt-14 pb-8`}>
+        {savedTitle != null && (
+          <div
+            className={`${sans.className} text-lg uppercase tracking-widest mb-6 shrink-0`}
+            style={{ color: 'rgb(0,175,154)' }}
+          >
+            {savedTitle}
+          </div>
+        )}
+        <div className="flex-1 min-h-0 flex flex-col">{s.content}</div>
+      </div>
+    ),
+  };
+}
+
+/** Slide 16 (Q&A): wrap content absolute so it covers the full slide. */
+function withFullBleedWrapper(s: SlideData): SlideData {
+  if (s.id !== 16) return s;
+  return {
+    ...s,
+    content: <div className="absolute inset-0">{s.content}</div>,
+  };
+}
+
+const archMapSlides = archMap.map(withInlineTitle);
+const funnelSlides = funnel.map(withInlineTitle);
+const closeSlides = close.map(withFullBleedWrapper);
+
+export const slides: SlideData[] = [
+  titleSlide,            // 1. Title
+  ...whatWeBuilt,        // 2. What we built (intro)
+  ...hook,               // 3. Hook · 4. Cycle
+  ...whyCi,              // 5. Why CI is the right first domain
+  ...archMapSlides,      // 6. ArchMap (Full picture)
+  ...playbookSlides,     // 7. Playbooks
+  ...funnelSlides,       // 8. Main loop
+  ...feedbackLoopSlides, // 9. Verification loop
+  ...vsAlternatives,     // 10. vs. Devin / Claude routines
+  ...naive,              // 11. Learning #1 — Specialized agents, not one big agent
+  ...keyInsight,         // 12. Learning #2 — One custom tool, not a chain of MCP calls
+  ...lessons,            // 13. Learning #3 — AutoResearch
+  ...results,            // 14. Results
+  ...closeSlides,        // 15. Q&A
+];

--- a/src/components/talks/pipeline-optimizer/slides/00b-what-we-built.tsx
+++ b/src/components/talks/pipeline-optimizer/slides/00b-what-we-built.tsx
@@ -1,0 +1,81 @@
+'use client';
+
+import React from 'react';
+import { motion } from 'framer-motion';
+import { Bot, GitPullRequest } from 'lucide-react';
+import { sans } from '@/lib/fonts';
+import { useSlideActs } from '../slide-acts-context';
+import type { SlideData } from './_types';
+
+function WhatWeBuilt() {
+  const { act } = useSlideActs();
+
+  return (
+    <div className="flex flex-col items-center justify-center h-full w-full text-center gap-8">
+      {/* Bot icon */}
+      <motion.div
+        initial={{ opacity: 0, scale: 0.75 }}
+        animate={{ opacity: act >= 1 ? 1 : 0, scale: act >= 1 ? 1 : 0.75 }}
+        transition={{ duration: 0.45, ease: 'easeOut' }}
+        className="flex items-center justify-center w-20 h-20 rounded-2xl border"
+        style={{
+          borderColor: 'rgba(0,175,154,0.4)',
+          backgroundColor: 'rgba(0,175,154,0.08)',
+          color: 'rgb(0,175,154)',
+        }}
+      >
+        <Bot size={40} strokeWidth={1.5} />
+      </motion.div>
+
+      {/* One-sentence descriptor */}
+      <motion.p
+        initial={{ opacity: 0, y: 12 }}
+        animate={{ opacity: act >= 1 ? 1 : 0, y: act >= 1 ? 0 : 12 }}
+        transition={{ duration: 0.5, ease: 'easeOut', delay: 0.12 }}
+        className={`${sans.className} text-3xl md:text-4xl font-semibold text-white leading-snug max-w-2xl`}
+      >
+        An agent that monitors our CI pipelines, spots inefficiencies, and ships PRs to fix them.
+      </motion.p>
+
+      {/* Output chip — → PRs */}
+      <motion.div
+        initial={{ opacity: 0, y: 8 }}
+        animate={{ opacity: act >= 1 ? 1 : 0, y: act >= 1 ? 0 : 8 }}
+        transition={{ duration: 0.38, ease: 'easeOut', delay: 0.25 }}
+        className="flex items-center gap-2 border rounded-full px-4 py-2"
+        style={{
+          borderColor: 'rgba(0,175,154,0.35)',
+          backgroundColor: 'rgba(0,175,154,0.07)',
+        }}
+      >
+        <span
+          className={`${sans.className} text-sm font-mono tracking-wide`}
+          style={{ color: 'rgba(0,175,154,0.8)' }}
+        >
+          output
+        </span>
+        <span className="text-white/30 text-xs">→</span>
+        <GitPullRequest size={15} style={{ color: 'rgb(0,175,154)' }} strokeWidth={1.8} />
+        <span
+          className={`${sans.className} text-sm font-semibold`}
+          style={{ color: 'rgb(0,175,154)' }}
+        >
+          PRs
+        </span>
+      </motion.div>
+    </div>
+  );
+}
+
+const whatWeBuiltSlide: SlideData[] = [
+  {
+    id: 18,
+    title: 'What we built',
+    acts: 2,
+    content: <WhatWeBuilt />,
+    notes:
+      'One sentence landing before the results hit. Give the audience a concrete mental model: this is an autonomous agent — not a script, not a dashboard — that closes the loop end-to-end, from observing CI to raising the fix.',
+  },
+];
+
+export default whatWeBuiltSlide;

--- a/src/components/talks/pipeline-optimizer/slides/01-hook.tsx
+++ b/src/components/talks/pipeline-optimizer/slides/01-hook.tsx
@@ -1,0 +1,212 @@
+'use client';
+// hook-results-builder: slides/01-hook.tsx → slides 2–3
+import React from 'react';
+import { motion } from 'framer-motion';
+import type { SlideData } from './_types';
+import { useSlideActs } from '../slide-acts-context';
+import { sans } from '@/lib/fonts';
+
+// ── Slide 02 — aggregate results (static, no staged reveal) ──────────────────
+function HookHero() {
+  return (
+    <div className="flex flex-col items-center justify-center h-full w-full text-center gap-6">
+      <div className={`${sans.className} text-9xl font-bold text-white tabular-nums`}>
+        80+
+      </div>
+      <div className={`${sans.className} text-2xl text-white/70`}>
+        pull requests merged
+      </div>
+      <div className={`${sans.className} text-xl text-white/55`}>
+        at 50%+ merge rate · across 20+ services
+      </div>
+      <div className="font-mono text-sm text-white/40 tracking-wide">
+        — first month —
+      </div>
+
+      {/* Flagship-win card */}
+      <div className="mt-8 border border-white/15 rounded-lg px-8 py-5 max-w-xl">
+        <div className="font-mono text-xs text-white/40 uppercase tracking-widest mb-3">
+          flagship win
+        </div>
+        <div className={`${sans.className} text-3xl font-mono text-white`}>
+          22 min → 8 min
+        </div>
+        <div className={`${sans.className} text-sm text-white/60 mt-2`}>
+          64% off · every feature CI build
+        </div>
+      </div>
+
+      <div className={`${sans.className} text-xl text-white/85 italic mt-6 max-w-2xl leading-relaxed`}>
+        I authored zero of them.
+        <br />I was asleep when most shipped.
+      </div>
+    </div>
+  );
+}
+
+// ── Slide 03 — The loop we kept losing ──────────────────────────────────────
+function CycleSlide() {
+  const { act } = useSlideActs();
+
+  const fadeIn = (atAct: number) => ({
+    initial: { opacity: 0, y: 8 },
+    animate: { opacity: act >= atAct ? 1 : 0, y: act >= atAct ? 0 : 8 },
+    transition: { duration: 0.4, ease: 'easeOut' as const },
+  });
+
+  const nodeAppear = (atAct: number) => ({
+    initial: { opacity: 0, scale: 0.82 },
+    animate: { opacity: act >= atAct ? 1 : 0, scale: act >= atAct ? 1 : 0.82 },
+    transition: { duration: 0.38, ease: 'easeOut' as const },
+  });
+
+  const arrowAppear = (atAct: number) => ({
+    initial: { opacity: 0 },
+    animate: { opacity: act >= atAct ? 0.35 : 0 },
+    transition: { duration: 0.25 },
+  });
+
+  return (
+    <div className="flex flex-col h-full w-full justify-center gap-6">
+      {/* ── 4-node flow row ── */}
+      <div className="flex items-start justify-between">
+        {/* Node 1 — Survey */}
+        <motion.div {...nodeAppear(1)} className="flex flex-col items-center gap-2" style={{ width: '20%' }}>
+          <div className="w-20 h-20 rounded-full border border-white/30 flex items-center justify-center font-mono text-sm text-white/70">
+            Survey
+          </div>
+          <div className={`${sans.className} text-[11px] text-center text-white/45 leading-snug`}>
+            CI slowness<br />tops the list
+          </div>
+          <div className="font-mono text-[10px] text-white/30 tracking-wide">— again —</div>
+        </motion.div>
+
+        {/* Arrow → */}
+        <motion.div {...arrowAppear(2)} className="text-white text-2xl self-center mb-10 flex-shrink-0">→</motion.div>
+
+        {/* Node 2 — Project */}
+        <motion.div {...nodeAppear(2)} className="flex flex-col items-center gap-2" style={{ width: '20%' }}>
+          <div className="w-20 h-20 rounded-full border border-white/30 flex items-center justify-center font-mono text-sm text-white/70">
+            Project
+          </div>
+          <div className={`${sans.className} text-[11px] text-center text-white/45 leading-snug`}>
+            30–40% off<br />worst pipelines
+          </div>
+          <div className="font-mono text-[10px] text-white/30 invisible">·</div>
+        </motion.div>
+
+        {/* Arrow → */}
+        <motion.div {...arrowAppear(3)} className="text-white text-2xl self-center mb-10 flex-shrink-0">→</motion.div>
+
+        {/* Node 3 — Win */}
+        <motion.div {...nodeAppear(3)} className="flex flex-col items-center gap-2" style={{ width: '20%' }}>
+          <div
+            className="w-20 h-20 rounded-full border-2 flex items-center justify-center font-mono text-sm font-bold"
+            style={{ borderColor: 'rgb(0,175,154)', color: 'rgb(0,175,154)', backgroundColor: 'rgba(0,175,154,0.1)' }}
+          >
+            Win
+          </div>
+          <div className={`${sans.className} text-[11px] text-center text-white/45 leading-snug`}>
+            15 min → 8 min<br />flagship pipeline
+          </div>
+          <div className="font-mono text-[10px] text-white/30 invisible">·</div>
+        </motion.div>
+
+        {/* Arrow → */}
+        <motion.div {...arrowAppear(4)} className="text-white text-2xl self-center mb-10 flex-shrink-0">→</motion.div>
+
+        {/* Node 4 — Drift */}
+        <motion.div {...nodeAppear(4)} className="flex flex-col items-center gap-2" style={{ width: '20%' }}>
+          <div
+            className="w-20 h-20 rounded-full border-2 flex items-center justify-center font-mono text-sm font-bold"
+            style={{ borderColor: 'rgb(255,167,196)', color: 'rgb(255,167,196)', backgroundColor: 'rgba(255,167,196,0.1)' }}
+          >
+            Drift
+          </div>
+          <div className={`${sans.className} text-[11px] text-center text-white/45 leading-snug`}>
+            8 min → 20 min<br />4 months later
+          </div>
+          <div className="font-mono text-[10px] tracking-wide" style={{ color: 'rgba(255,167,196,0.55)' }}>
+            same pipeline
+          </div>
+        </motion.div>
+      </div>
+
+      {/* ── Loop-back arc (Drift → Survey) ── */}
+      <div className="relative -mt-2">
+        {/*
+          viewBox 0 0 1200 100 keeps x/y scales close to 1:1 at typical slide widths,
+          preventing the horizontal crush that flattened the old 100×22 viewBox.
+          Arc dips to y=90 for a clearly visible curve (~80px drop at 100px height).
+        */}
+        <svg
+          viewBox="0 0 1200 100"
+          preserveAspectRatio="none"
+          className="w-full overflow-visible"
+          style={{ width: '100%', height: 100 }}
+        >
+          {/* Arc from Drift side (~90%) back to Survey side (~10%) */}
+          <motion.path
+            d="M 1080 12 C 1080 90, 120 90, 120 12"
+            fill="none"
+            stroke="rgba(255,167,196,0.85)"
+            strokeWidth="3"
+            initial={{ pathLength: 0, opacity: 0 }}
+            animate={{ pathLength: act >= 5 ? 1 : 0, opacity: act >= 5 ? 1 : 0 }}
+            transition={{ duration: 0.85, ease: 'easeInOut' }}
+          />
+          {/* Arrowhead at Survey end pointing upward (tip at y=2, overflows into node area) */}
+          <motion.polygon
+            points="120,2 112,18 128,18"
+            fill="rgba(255,167,196,0.85)"
+            initial={{ opacity: 0 }}
+            animate={{ opacity: act >= 5 ? 1 : 0 }}
+            transition={{ delay: 0.7, duration: 0.3 }}
+          />
+        </svg>
+        <motion.div
+          {...fadeIn(5)}
+          className="text-center font-mono text-[10px] text-white/30 tracking-widest -mt-1"
+        >
+          next quarter · same answer
+        </motion.div>
+      </div>
+
+      {/* ── Punchline ── */}
+      <motion.div
+        {...fadeIn(6)}
+        className={`${sans.className} text-2xl font-semibold text-center leading-snug mt-1`}
+        style={{ color: 'rgb(0,175,154)' }}
+      >
+        This time — the last CI project we&apos;d ever run.
+      </motion.div>
+    </div>
+  );
+}
+
+const slides: SlideData[] = [
+  {
+    id: 2,
+    title: undefined,
+    content: <HookHero />,
+    notes: `In about a month since launch, 80+ pull requests merged at a 50%+ merge rate, across 20+ services. The biggest single win — a service went from 22 minutes to 8 minutes on every feature CI run. Obviously there were many PRs that were not merged but the thing that makes it trustworthy is system validates the change looking at CI runs.`,
+  },
+
+  {
+    id: 3,
+    title: 'The loop we kept losing',
+    acts: 7,
+    content: <CycleSlide />,
+    notes: `Each quarter, the developer experience survey came back with the same answer near the top: CI is too slow. And each quarter, the team would scope a project — pick the highest-traffic pipelines, apply best practices, ship real wins. The headline quarter: 30–40% off the worst offenders. One pipeline went from 15 minutes down to 8 minutes.
+
+A few months later, that same pipeline was running at 20 minutes. Something changed, someone noticed, it got fixed. Then the next quarterly survey landed. CI slowness: near the top of the list, again.
+
+One year after the biggest push, the team looked at the regression dashboard — the one built explicitly to catch this — and it read: flat year-over-year. Median pipeline duration had not improved. Meanwhile, the average PR had grown substantially (AI-assisted authoring, more changes per developer). The math was getting worse in per-engineer-hour terms, even while raw minutes held flat.
+
+TODO(tulsi): confirm exact number of quarters CI topped the survey — research says "7+ surveys in the last ~18 months, CI consistently a top frustration"; use whichever framing you're comfortable defending.
+
+The cycle wasn't a knowledge problem. The team knew what was slow and had the fixes documented. The problem was propagation: one team, many repos, each fix needing a manual PR per repo to apply, and no mechanism to detect drift before the next survey. This would be the last CI project run by hand.`,
+  },
+];
+
+export default slides;

--- a/src/components/talks/pipeline-optimizer/slides/03-naive.tsx
+++ b/src/components/talks/pipeline-optimizer/slides/03-naive.tsx
@@ -1,0 +1,160 @@
+// porter-A: slides/03-naive-approach.md → slide Learning #1 (merged)
+import React from 'react';
+import { motion } from 'framer-motion';
+import type { SlideData } from './_types';
+import { useSlideActs } from '../slide-acts-context';
+import { sans } from '@/lib/fonts';
+
+// ── Slide — Learning #1: One big agent. Everything. ───────────────────────────
+// Widened: viewBox 1100×280, nodes on oval rx≈440 ry≈95, center 550 135.
+// Container aspect-ratio drives near-full-width fill; maxHeight caps vertical space.
+const spokeNodes = [
+  { x: 204, y:  64, dy: -12, label: 'read pipeline YAML' },
+  { x: 550, y:  35, dy: -12, label: 'check CI docs' },
+  { x: 896, y:  64, dy: -12, label: 'understand context' },
+  { x: 1040, y: 135, dy:   5, label: 'apply playbook' },
+  { x: 896, y: 206, dy:  20, label: 'commit + push' },
+  { x: 550, y: 235, dy:  20, label: 'decide when done' },
+  { x: 204, y: 206, dy:  20, label: 'self-correct on error' },
+  { x:  60, y: 135, dy:   5, label: 'pick which tools' },
+];
+
+const failures = [
+  {
+    icon: '⏱',
+    title: 'Turn budget exploded',
+    detail: 'No cap — runs of 200+ turns chasing context the agent already had.',
+  },
+  {
+    icon: '🧨',
+    title: 'Confidently wrong YAML',
+    detail: 'Pipeline-valid, semantically broken — depends_on silently dropped, caught 6 builds later.',
+  },
+  {
+    icon: '🪞',
+    title: 'Rationalized bad diffs',
+    detail: 'CI green + no turn pressure = agent convincing itself the change was fine.',
+  },
+  {
+    icon: '🔍',
+    title: 'Opaque when it broke',
+    detail: 'Hundreds of turns to read, no clean signal on which reasoning step failed.',
+  },
+];
+
+function Learning1Slide() {
+  const { act } = useSlideActs();
+
+  const fadeIn = (atAct: number, delay = 0) => ({
+    initial: { opacity: 0, y: 8 },
+    animate: { opacity: act >= atAct ? 1 : 0, y: act >= atAct ? 0 : 8 },
+    transition: { duration: 0.4, delay: delay / 1000, ease: 'easeOut' as const },
+  });
+
+  return (
+    <div className="flex flex-col h-full w-full gap-4">
+      {/* ── Row 1: Agent diagram — full width, act 1 ── */}
+      {/*
+        aspect-ratio: 1100/280 (very flat) + maxHeight: 370 lets SVG render at scale ~1.32,
+        giving ~85% content-width fill (nodes at x=60..1040 span most of the slide).
+        370px leaves ~370px below for stats + cards.
+      */}
+      <div
+        className="w-full shrink-0"
+        style={{ aspectRatio: '1100 / 280', maxHeight: 370 }}
+      >
+        <svg
+          viewBox="0 0 1100 280"
+          style={{ width: '100%', height: '100%' }}
+          overflow="visible"
+        >
+          {/* center agent circle — always visible */}
+          <circle
+            cx="550" cy="135" r="42"
+            fill="rgba(0,175,154,0.9)"
+            stroke="rgba(0,175,154,0.5)"
+            strokeWidth="2.5"
+          />
+          <text
+            x="550" y="141"
+            textAnchor="middle"
+            fontSize="16"
+            fontFamily="monospace"
+            fill="white"
+          >
+            agent
+          </text>
+
+          {/* 8 responsibility spokes — appear act 1, staggered */}
+          {spokeNodes.map((node, i) => (
+            <motion.g key={node.label} {...fadeIn(1, i * 60)}>
+              <line
+                x1="550" y1="135"
+                x2={node.x} y2={node.y}
+                stroke="rgba(255,255,255,0.25)"
+                strokeWidth="2"
+              />
+              <circle cx={node.x} cy={node.y} r="4" fill="rgba(255,255,255,0.55)" />
+              <text
+                x={node.x} y={node.y}
+                dy={node.dy}
+                textAnchor="middle"
+                fontSize="16"
+                fontFamily="monospace"
+                fill="rgba(255,255,255,0.75)"
+              >
+                {node.label}
+              </text>
+            </motion.g>
+          ))}
+        </svg>
+      </div>
+
+      {/* ── Row 2: Stats trio — act 2 ── */}
+      <motion.div {...fadeIn(2)} className="grid grid-cols-3 gap-4 shrink-0">
+        <div className="border border-white/15 rounded-lg p-4 text-center">
+          <div className="font-mono text-xs uppercase tracking-widest text-white/40 mb-2">model</div>
+          <div className="font-mono text-xl text-white">Sonnet</div>
+        </div>
+        <div className="border border-white/15 rounded-lg p-4 text-center">
+          <div className="font-mono text-xs uppercase tracking-widest text-white/40 mb-2">turn cap</div>
+          <div className="font-mono text-xl text-white">unbounded</div>
+        </div>
+        <div className="border rounded-lg p-4 text-center" style={{ borderColor: 'rgba(255,167,196,0.4)' }}>
+          <div className="font-mono text-xs uppercase tracking-widest text-white/40 mb-2">success rate</div>
+          <div className="font-mono text-xl" style={{ color: 'rgb(255,167,196)' }}>~50%</div>
+        </div>
+      </motion.div>
+
+      {/* ── Row 3: Failure cards — acts 3–4 ── */}
+      <div className="grid grid-cols-2 gap-4 flex-1 min-h-0">
+        {failures.map((f, i) => (
+          <motion.div
+            key={f.title}
+            {...fadeIn(i < 2 ? 3 : 4, (i % 2) * 100)}
+            className="border border-white/15 rounded-lg p-5 flex gap-4 items-start"
+          >
+            <div className="text-2xl shrink-0">{f.icon}</div>
+            <div className="flex flex-col gap-1.5">
+              <div className={`${sans.className} text-base font-semibold text-white`}>{f.title}</div>
+              <div className={`${sans.className} text-sm text-white/60 leading-relaxed`}>{f.detail}</div>
+            </div>
+          </motion.div>
+        ))}
+      </div>
+    </div>
+  );
+}
+
+const slides: SlideData[] = [
+  {
+    id: 5,
+    title: 'Learning #1: Specialized agents, not one big agent',
+    acts: 4,
+    content: <Learning1Slide />,
+    notes:
+      "The first implementation was exactly what you'd build if you hadn't yet learned any of the lessons this talk is about. One agent. One prompt. Full Buildkite API access. No turn cap. Told to read the pipeline, understand the context, apply the fix, and commit — all in a single pass. We used Sonnet, which is capable, and we gave it everything we thought it might need. It ran. It produced outputs. And about half the time, those outputs were technically correct. The CI passed. The YAML was valid. And something was subtly wrong.\n\nThree failures showed up quickly. First: CI-valid-but-wrong diffs. The agent would produce a change that passed linting and CI, but had subtly broken a dependency chain — treating an implicit wait barrier as something that could be removed, or dropping a depends_on relationship that a downstream step actually needed. Second: turn explosion. One agent trying to answer everything simultaneously would spend turns exploring history it didn't need. Third — and this is the one that really stuck — when it went wrong, I had no idea where. Hundreds of turns to read, no clean signal about which reasoning step had failed. You can't improve what you can't see. You can't trust what you can't understand. The funnel is the answer to all three of these.",
+  },
+];
+
+export default slides;

--- a/src/components/talks/pipeline-optimizer/slides/04-architecture.tsx
+++ b/src/components/talks/pipeline-optimizer/slides/04-architecture.tsx
@@ -1,0 +1,463 @@
+'use client';
+
+// Slide 04 — "The full picture"
+// Faithful reproduction of tulsi-architecture-diagram.excalidraw.json
+//
+// Three-column layout (left → right):
+//   Col 1: Result → GitHub PR
+//   Col 2: Agentic Pipelines/Loops (nested)
+//           └─ Main loop (dashed): Pre Screen/Plan → Implementation ↔ Review
+//           └─ Verification Loop (red dashed): Comment Triage/Fix, CI Failure, Fix Verification
+//   Col 3: Contexts (orange dashed, top) + Playbooks (orange dashed, bottom)
+//           Contexts: Pipeline Logs/Metrics, PR Request Reviews, Lint/Policies
+//           Playbooks: stacked nested cards with optimisation items
+//
+// Acts: 0=all-dimmed  1=playbooks  2=pre-screen/plan  3=impl↔review
+//       4=contexts  5=github-pr  6=verification-loop
+
+import React from 'react';
+import { motion } from 'framer-motion';
+import type { SlideData } from './_types';
+import { FunnelAnimation } from '../funnel-animation';
+import { useSlideActs } from '../slide-acts-context';
+
+// ── Brand ─────────────────────────────────────────────────────────────────────
+const GREEN  = 'rgb(0,175,154)';
+const PINK   = 'rgb(255,167,196)';
+const ORANGE = 'rgb(240,140,0)';
+const RED    = 'rgb(224,49,49)';
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+type R = { x: number; y: number; w: number; h: number };
+const cx = (r: R) => r.x + r.w / 2;
+const cy = (r: R) => r.y + r.h / 2;
+
+// ── Geometry (viewBox 1000 × 520) ────────────────────────────────────────────
+const VW = 1000;
+const VH  = 520;
+const P   = 12; // outer padding
+
+// Three columns:
+//  C1 x=10..118 (w=108)   gap=30   C2 x=148..468 (w=320)   gap=30   C3 x=498..988 (w=490)
+const C1 = { x: 10,  w: 108 };
+const C2 = { x: 148, w: 320 };
+const C3 = { x: 498, w: 490 };
+
+// Col 1 — Result
+const RES_BOX:  R = { x: C1.x,      y: P,   w: C1.w,      h: VH - P * 2 };
+const PR_BLOCK: R = { x: C1.x + 8,  y: 162, w: C1.w - 16, h: 96 };
+
+// Col 2 — Agentic Pipelines/Loops outer
+const AGT_BOX:  R = { x: C2.x,      y: P,   w: C2.w,      h: VH - P * 2 };
+
+// Main loop inner section
+const ML_BOX:   R = { x: C2.x + 9,  y: 38,  w: C2.w - 18, h: 208 };
+const PLAN_B:   R = { x: C2.x + 18, y: 54,  w: C2.w - 36, h: 48 };
+const IMPL_B:   R = { x: C2.x + 18, y: 110, w: C2.w - 36, h: 48 };
+const REV_B:    R = { x: C2.x + 18, y: 166, w: C2.w - 36, h: 48 };
+
+// After PR created inner section
+const APR_BOX:  R = { x: C2.x + 9,  y: 264, w: C2.w - 18, h: 232 };
+const TRG_B:    R = { x: C2.x + 18, y: 280, w: C2.w - 36, h: 48 };
+const CIF_B:    R = { x: C2.x + 18, y: 336, w: C2.w - 36, h: 48 };
+const FVR_B:    R = { x: C2.x + 18, y: 392, w: C2.w - 36, h: 48 };
+
+// Col 3 — Contexts (top half)
+const CTX_BOX:  R = { x: C3.x,      y: P,   w: C3.w,      h: 242 };
+const CTX_B1:   R = { x: C3.x + 10, y: 38,  w: C3.w - 20, h: 58 };
+const CTX_B2:   R = { x: C3.x + 10, y: 104, w: C3.w - 20, h: 58 };
+const CTX_B3:   R = { x: C3.x + 10, y: 170, w: C3.w - 20, h: 58 };
+
+// Col 3 — Playbooks (bottom half)
+const PLB_BOX:  R = { x: C3.x,      y: 268, w: C3.w,      h: VH - P - 268 };
+const PLB_CARD1:R = { x: C3.x + 10, y: 298, w: C3.w - 20, h: 110 }; // back card
+const PLB_CARD2:R = { x: C3.x + 22, y: 312, w: C3.w - 44, h: 110 }; // front card
+
+// Gap X mid-points for elbow connectors
+const GAP1_X = C1.x + C1.w + 15; // 133  (in the gap between Col1 and Col2)
+
+// ── ArchMap ───────────────────────────────────────────────────────────────────
+function ArchMap() {
+  const { act } = useSlideActs();
+
+  const FONT = 'Montserrat,ui-sans-serif,system-ui';
+  const MONO = 'ui-monospace,monospace';
+
+  const DIM = 0.20;
+
+  /** Dim-then-highlight: act 0 = all visible at DIM; each act brightens one section cumulatively */
+  const highlight = (n: number, delay = 0) => ({
+    initial:    { opacity: DIM },
+    animate:    { opacity: act >= n ? 1 : DIM },
+    transition: { duration: 0.4, ease: 'easeOut' as const, delay: act >= n ? delay : 0 },
+  });
+
+  // Shared sub-label style
+  const sub = { fontSize: 8.5, fill: 'rgba(255,255,255,0.40)', fontFamily: MONO } as const;
+
+  return (
+    <div style={{ flex: 1, width: '100%', minHeight: 0, overflow: 'hidden' }}>
+      <svg viewBox={`0 0 ${VW} ${VH}`} style={{ width: '100%', height: '100%', display: 'block' }}>
+        <defs>
+          <marker id="am-teal"   viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto">
+            <path d="M0 0 L10 5 L0 10z" fill={GREEN} />
+          </marker>
+          <marker id="am-pink"   viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto">
+            <path d="M0 0 L10 5 L0 10z" fill={PINK} />
+          </marker>
+          <marker id="am-orange" viewBox="0 0 10 10" refX="9" refY="5" markerWidth="5" markerHeight="5" orient="auto">
+            <path d="M0 0 L10 5 L0 10z" fill={ORANGE} />
+          </marker>
+
+          <linearGradient id="am-g-green" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%"   stopColor="rgba(0,175,154,0.22)" />
+            <stop offset="100%" stopColor="rgba(0,175,154,0.06)" />
+          </linearGradient>
+          <linearGradient id="am-g-pink" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%"   stopColor="rgba(255,167,196,0.22)" />
+            <stop offset="100%" stopColor="rgba(255,167,196,0.06)" />
+          </linearGradient>
+          <linearGradient id="am-g-white" x1="0" y1="0" x2="0" y2="1">
+            <stop offset="0%"   stopColor="rgba(255,255,255,0.09)" />
+            <stop offset="100%" stopColor="rgba(255,255,255,0.02)" />
+          </linearGradient>
+        </defs>
+
+        {/* ═══════════════════════════════════════════════════════════════════ */}
+        {/* ACT 5 — GitHub PR (Result column)                                 */}
+        {/* ═══════════════════════════════════════════════════════════════════ */}
+        <motion.g {...highlight(5)}>
+          {/* Outer dashed container */}
+          <rect x={RES_BOX.x} y={RES_BOX.y} width={RES_BOX.w} height={RES_BOX.h} rx={8}
+            fill="rgba(255,255,255,0.015)" stroke="rgba(255,255,255,0.22)" strokeWidth={1.5}
+            strokeDasharray="6 4" />
+          <text x={RES_BOX.x + 6} y={RES_BOX.y + 15}
+            fontSize="7.5" fill="rgba(255,255,255,0.38)" fontFamily={FONT} fontWeight="600">
+            Result
+          </text>
+
+          {/* GitHub PR block */}
+          <rect x={PR_BLOCK.x} y={PR_BLOCK.y} width={PR_BLOCK.w} height={PR_BLOCK.h} rx={6}
+            fill="url(#am-g-green)" stroke={GREEN} strokeWidth={1.5} />
+          <text x={cx(PR_BLOCK)} y={cy(PR_BLOCK) - 10}
+            textAnchor="middle" dominantBaseline="middle"
+            fontSize="11" fontWeight="700" fill={GREEN} fontFamily={FONT}>
+            GitHub PR
+          </text>
+          <text x={cx(PR_BLOCK)} y={cy(PR_BLOCK) + 10}
+            textAnchor="middle" dominantBaseline="middle" {...sub}>
+            review · merge
+          </text>
+        </motion.g>
+
+        {/* ═══════════════════════════════════════════════════════════════════ */}
+        {/* ACT 2 — Agentic outer + Main loop container + Pre Screen / Plan   */}
+        {/* ═══════════════════════════════════════════════════════════════════ */}
+        <motion.g {...highlight(2)}>
+          {/* Outer dashed container */}
+          <rect x={AGT_BOX.x} y={AGT_BOX.y} width={AGT_BOX.w} height={AGT_BOX.h} rx={8}
+            fill="rgba(255,255,255,0.015)" stroke="rgba(255,255,255,0.28)" strokeWidth={1.5}
+            strokeDasharray="6 4" />
+          <text x={AGT_BOX.x + 8} y={AGT_BOX.y + 15}
+            fontSize="7.5" fontWeight="700" fill="rgba(255,255,255,0.55)" fontFamily={FONT}>
+            Agentic Pipelines / Loops
+          </text>
+
+          {/* Main loop inner dashed container */}
+          <rect x={ML_BOX.x} y={ML_BOX.y} width={ML_BOX.w} height={ML_BOX.h} rx={6}
+            fill="rgba(255,255,255,0.02)" stroke="rgba(255,255,255,0.22)" strokeWidth={1.2}
+            strokeDasharray="5 3" />
+          <text x={ML_BOX.x + 7} y={ML_BOX.y + 12}
+            fontSize="7" fill="rgba(255,255,255,0.38)" fontFamily={FONT}>
+            Main loop
+          </text>
+
+          {/* Pre Screen / Plan */}
+          <rect x={PLAN_B.x} y={PLAN_B.y} width={PLAN_B.w} height={PLAN_B.h} rx={6}
+            fill="url(#am-g-green)" stroke={GREEN} strokeWidth={1.5} />
+          <text x={cx(PLAN_B)} y={cy(PLAN_B) - 8}
+            textAnchor="middle" dominantBaseline="middle"
+            fontSize="12" fontWeight="600" fill={GREEN} fontFamily={FONT}>
+            Pre Screen / Plan
+          </text>
+          <text x={cx(PLAN_B)} y={cy(PLAN_B) + 9}
+            textAnchor="middle" dominantBaseline="middle" {...sub}>
+            triage · scope · intent
+          </text>
+        </motion.g>
+
+        {/* ═══════════════════════════════════════════════════════════════════ */}
+        {/* ACT 3 — Implementation, Review + Plan→Impl arrow + bidir arrows   */}
+        {/* ═══════════════════════════════════════════════════════════════════ */}
+        <motion.g {...highlight(3)}>
+          {/* Arrow: Plan → Implementation */}
+          <path d={`M${cx(PLAN_B)} ${PLAN_B.y + PLAN_B.h + 1} L${cx(IMPL_B)} ${IMPL_B.y - 1}`}
+            stroke={GREEN} strokeWidth={1.5} fill="none"
+            markerEnd="url(#am-teal)" strokeLinecap="round" />
+
+          {/* Implementation */}
+          <rect x={IMPL_B.x} y={IMPL_B.y} width={IMPL_B.w} height={IMPL_B.h} rx={6}
+            fill="url(#am-g-green)" stroke={GREEN} strokeWidth={1.5} />
+          <text x={cx(IMPL_B)} y={cy(IMPL_B) - 8}
+            textAnchor="middle" dominantBaseline="middle"
+            fontSize="12" fontWeight="600" fill={GREEN} fontFamily={FONT}>
+            Implementation
+          </text>
+          <text x={cx(IMPL_B)} y={cy(IMPL_B) + 9}
+            textAnchor="middle" dominantBaseline="middle" {...sub}>
+            write · diff · commit
+          </text>
+
+          {/* Review */}
+          <rect x={REV_B.x} y={REV_B.y} width={REV_B.w} height={REV_B.h} rx={6}
+            fill="url(#am-g-green)" stroke={GREEN} strokeWidth={1.5} />
+          <text x={cx(REV_B)} y={cy(REV_B) - 8}
+            textAnchor="middle" dominantBaseline="middle"
+            fontSize="12" fontWeight="600" fill={GREEN} fontFamily={FONT}>
+            Review
+          </text>
+          <text x={cx(REV_B)} y={cy(REV_B) + 9}
+            textAnchor="middle" dominantBaseline="middle" {...sub}>
+            compliance · correctness · security
+          </text>
+
+          {/* Left side: Impl → Review (elbow down-left) */}
+          <path
+            d={`M${IMPL_B.x} ${cy(IMPL_B)} L${IMPL_B.x - 14} ${cy(IMPL_B)} L${IMPL_B.x - 14} ${cy(REV_B)} L${REV_B.x} ${cy(REV_B)}`}
+            stroke={PINK} strokeWidth={1.8} fill="none"
+            markerEnd="url(#am-pink)" strokeLinecap="round" strokeLinejoin="round" />
+          {/* Right side: Review → Impl (elbow up-right) */}
+          <path
+            d={`M${REV_B.x + REV_B.w} ${cy(REV_B)} L${REV_B.x + REV_B.w + 14} ${cy(REV_B)} L${REV_B.x + REV_B.w + 14} ${cy(IMPL_B)} L${IMPL_B.x + IMPL_B.w} ${cy(IMPL_B)}`}
+            stroke={PINK} strokeWidth={1.8} fill="none"
+            markerEnd="url(#am-pink)" strokeLinecap="round" strokeLinejoin="round" />
+          {/* "Verification Loop" rotated label (between the two arrows) */}
+          <text
+            x={IMPL_B.x - 16}
+            y={(cy(IMPL_B) + cy(REV_B)) / 2}
+            textAnchor="middle" fontSize="7" fill={PINK} fontFamily={MONO}
+            transform={`rotate(-90,${IMPL_B.x - 16},${(cy(IMPL_B) + cy(REV_B)) / 2})`}>
+            Verification Loop
+          </text>
+        </motion.g>
+
+        {/* ═══════════════════════════════════════════════════════════════════ */}
+        {/* ACT 6 — Verification Loop section + After-PR→PR connector         */}
+        {/* ═══════════════════════════════════════════════════════════════════ */}
+        <motion.g {...highlight(6)}>
+          {/* "Verification Loop" red label above container */}
+          <text x={APR_BOX.x + 7} y={APR_BOX.y - 6}
+            fontSize="7.5" fontWeight="700" fill={RED} fontFamily={FONT}>
+            Verification Loop
+          </text>
+
+          {/* Red dashed container */}
+          <rect x={APR_BOX.x} y={APR_BOX.y} width={APR_BOX.w} height={APR_BOX.h} rx={6}
+            fill="rgba(224,49,49,0.05)" stroke={RED} strokeWidth={1.5}
+            strokeDasharray="6 4" />
+
+          {/* Comment Triage / Fix */}
+          <rect x={TRG_B.x} y={TRG_B.y} width={TRG_B.w} height={TRG_B.h} rx={6}
+            fill="url(#am-g-pink)" stroke={PINK} strokeWidth={1.5} />
+          <text x={cx(TRG_B)} y={cy(TRG_B) - 8}
+            textAnchor="middle" dominantBaseline="middle"
+            fontSize="12" fontWeight="600" fill={PINK} fontFamily={FONT}>
+            Comment Triage / Fix
+          </text>
+          <text x={cx(TRG_B)} y={cy(TRG_B) + 9}
+            textAnchor="middle" dominantBaseline="middle" {...sub}>
+            parse · prioritise · apply
+          </text>
+
+          {/* CI Failure */}
+          <rect x={CIF_B.x} y={CIF_B.y} width={CIF_B.w} height={CIF_B.h} rx={6}
+            fill="url(#am-g-pink)" stroke={PINK} strokeWidth={1.5} />
+          <text x={cx(CIF_B)} y={cy(CIF_B) - 8}
+            textAnchor="middle" dominantBaseline="middle"
+            fontSize="12" fontWeight="600" fill={PINK} fontFamily={FONT}>
+            CI Failure
+          </text>
+          <text x={cx(CIF_B)} y={cy(CIF_B) + 9}
+            textAnchor="middle" dominantBaseline="middle" {...sub}>
+            diagnose · patch · re-run
+          </text>
+
+          {/* Fix Verification */}
+          <rect x={FVR_B.x} y={FVR_B.y} width={FVR_B.w} height={FVR_B.h} rx={6}
+            fill="url(#am-g-pink)" stroke={PINK} strokeWidth={1.5} />
+          <text x={cx(FVR_B)} y={cy(FVR_B) - 8}
+            textAnchor="middle" dominantBaseline="middle"
+            fontSize="12" fontWeight="600" fill={PINK} fontFamily={FONT}>
+            Fix Verification
+          </text>
+          <text x={cx(FVR_B)} y={cy(FVR_B) + 9}
+            textAnchor="middle" dominantBaseline="middle" {...sub}>
+            confirm · update PR
+          </text>
+
+          {/* After PR → GitHub PR (dashed pink elbow) */}
+          <path
+            d={`M${AGT_BOX.x} ${cy(APR_BOX)} L${GAP1_X} ${cy(APR_BOX)} L${GAP1_X} ${cy(PR_BLOCK) + 14} L${C1.x + C1.w} ${cy(PR_BLOCK) + 14}`}
+            stroke={PINK} strokeWidth={1.5} fill="none"
+            strokeDasharray="5 3" markerEnd="url(#am-pink)"
+            strokeLinecap="round" strokeLinejoin="round" />
+        </motion.g>
+
+        {/* ACT 5 (delayed) — Main loop → GitHub PR connector                 */}
+        <motion.g {...highlight(5, 0.1)}>
+          <path
+            d={`M${AGT_BOX.x} ${cy(ML_BOX)} L${GAP1_X} ${cy(ML_BOX)} L${GAP1_X} ${cy(PR_BLOCK) - 14} L${C1.x + C1.w} ${cy(PR_BLOCK) - 14}`}
+            stroke={GREEN} strokeWidth={1.5} fill="none"
+            strokeDasharray="5 3" markerEnd="url(#am-teal)"
+            strokeLinecap="round" strokeLinejoin="round" />
+        </motion.g>
+
+        {/* ═══════════════════════════════════════════════════════════════════ */}
+        {/* ACT 4 — Contexts section                                           */}
+        {/* ═══════════════════════════════════════════════════════════════════ */}
+        <motion.g {...highlight(4)}>
+          {/* Orange dashed outer container */}
+          <rect x={CTX_BOX.x} y={CTX_BOX.y} width={CTX_BOX.w} height={CTX_BOX.h} rx={8}
+            fill="rgba(240,140,0,0.04)" stroke={ORANGE} strokeWidth={1.5}
+            strokeDasharray="6 4" />
+          <text x={CTX_BOX.x + 8} y={CTX_BOX.y + 15}
+            fontSize="7.5" fontWeight="700" fill={ORANGE} fontFamily={FONT}>
+            Contexts
+          </text>
+
+          {/* Pipeline Logs / Metrics */}
+          <rect x={CTX_B1.x} y={CTX_B1.y} width={CTX_B1.w} height={CTX_B1.h} rx={6}
+            fill="url(#am-g-white)" stroke="rgba(255,255,255,0.26)" strokeWidth={1.2} />
+          <text x={cx(CTX_B1)} y={cy(CTX_B1) - 9}
+            textAnchor="middle" dominantBaseline="middle"
+            fontSize="12" fontWeight="600" fill="rgba(255,255,255,0.82)" fontFamily={FONT}>
+            Pipeline Logs / Metrics
+          </text>
+          <text x={cx(CTX_B1)} y={cy(CTX_B1) + 9}
+            textAnchor="middle" dominantBaseline="middle" {...sub}>
+            build output · timings · failures
+          </text>
+
+          {/* PR Request Reviews */}
+          <rect x={CTX_B2.x} y={CTX_B2.y} width={CTX_B2.w} height={CTX_B2.h} rx={6}
+            fill="url(#am-g-white)" stroke="rgba(255,255,255,0.26)" strokeWidth={1.2} />
+          <text x={cx(CTX_B2)} y={cy(CTX_B2) - 9}
+            textAnchor="middle" dominantBaseline="middle"
+            fontSize="12" fontWeight="600" fill="rgba(255,255,255,0.82)" fontFamily={FONT}>
+            PR Request Reviews
+          </text>
+          <text x={cx(CTX_B2)} y={cy(CTX_B2) + 9}
+            textAnchor="middle" dominantBaseline="middle" {...sub}>
+            comments · approvals · history
+          </text>
+
+          {/* Lint / Best Practices / Policies */}
+          <rect x={CTX_B3.x} y={CTX_B3.y} width={CTX_B3.w} height={CTX_B3.h} rx={6}
+            fill="url(#am-g-white)" stroke="rgba(255,255,255,0.26)" strokeWidth={1.2} />
+          <text x={cx(CTX_B3)} y={cy(CTX_B3) - 9}
+            textAnchor="middle" dominantBaseline="middle"
+            fontSize="12" fontWeight="600" fill="rgba(255,255,255,0.82)" fontFamily={FONT}>
+            Lint / Best Practices / Policies
+          </text>
+          <text x={cx(CTX_B3)} y={cy(CTX_B3) + 9}
+            textAnchor="middle" dominantBaseline="middle" {...sub}>
+            rules · style guides · CI docs
+          </text>
+
+          {/* Arrow: Contexts → Agentic (left-pointing dashed) */}
+          <path
+            d={`M${CTX_BOX.x} ${cy(CTX_BOX)} L${AGT_BOX.x + AGT_BOX.w} ${cy(CTX_BOX)}`}
+            stroke={ORANGE} strokeWidth={1.5} fill="none"
+            strokeDasharray="5 3" markerEnd="url(#am-orange)" strokeLinecap="round" />
+        </motion.g>
+
+        {/* ═══════════════════════════════════════════════════════════════════ */}
+        {/* ACT 1 — Playbooks section                                          */}
+        {/* ═══════════════════════════════════════════════════════════════════ */}
+        <motion.g {...highlight(1)}>
+          {/* Orange dashed outer container */}
+          <rect x={PLB_BOX.x} y={PLB_BOX.y} width={PLB_BOX.w} height={PLB_BOX.h} rx={8}
+            fill="rgba(240,140,0,0.04)" stroke={ORANGE} strokeWidth={1.5}
+            strokeDasharray="6 4" />
+          <text x={PLB_BOX.x + 8} y={PLB_BOX.y + 15}
+            fontSize="7.5" fontWeight="700" fill={ORANGE} fontFamily={FONT}>
+            Playbooks
+          </text>
+
+          {/* Back card (stacked depth effect) */}
+          <rect x={PLB_CARD1.x} y={PLB_CARD1.y} width={PLB_CARD1.w} height={PLB_CARD1.h} rx={6}
+            fill="rgba(255,255,255,0.015)" stroke="rgba(255,255,255,0.18)" strokeWidth={1}
+            strokeDasharray="5 3" />
+          {/* Front card (slightly offset) */}
+          <rect x={PLB_CARD2.x} y={PLB_CARD2.y} width={PLB_CARD2.w} height={PLB_CARD2.h} rx={6}
+            fill="rgba(255,255,255,0.05)" stroke="rgba(255,255,255,0.30)" strokeWidth={1.2}
+            strokeDasharray="5 3" />
+
+          {/* Content: item 1 */}
+          <text x={PLB_CARD2.x + 14} y={PLB_CARD2.y + 22}
+            fontSize="11" fontWeight="600" fill="rgba(255,255,255,0.78)" fontFamily={FONT}>
+            Use container layer caching
+          </text>
+          <text x={PLB_CARD2.x + 14} y={PLB_CARD2.y + 40}
+            fontSize="8.5" fill="rgba(255,255,255,0.35)" fontFamily={MONO}>
+            registry-level cache per step
+          </text>
+
+          {/* Divider */}
+          <line x1={PLB_CARD2.x + 14} y1={PLB_CARD2.y + 54}
+            x2={PLB_CARD2.x + PLB_CARD2.w - 14} y2={PLB_CARD2.y + 54}
+            stroke="rgba(255,255,255,0.12)" strokeWidth={1} />
+
+          {/* Content: item 2 */}
+          <text x={PLB_CARD2.x + 14} y={PLB_CARD2.y + 72}
+            fontSize="11" fontWeight="600" fill="rgba(255,255,255,0.78)" fontFamily={FONT}>
+            Parallelise CI steps
+          </text>
+          <text x={PLB_CARD2.x + 14} y={PLB_CARD2.y + 90}
+            fontSize="8.5" fill="rgba(255,255,255,0.35)" fontFamily={MONO}>
+            fan-out where dependency graph allows
+          </text>
+
+          {/* Arrow: Playbooks → Agentic (left-pointing dashed) */}
+          <path
+            d={`M${PLB_BOX.x} ${cy(PLB_BOX)} L${AGT_BOX.x + AGT_BOX.w} ${cy(PLB_BOX)}`}
+            stroke={ORANGE} strokeWidth={1.5} fill="none"
+            strokeDasharray="5 3" markerEnd="url(#am-orange)" strokeLinecap="round" />
+        </motion.g>
+
+      </svg>
+    </div>
+  );
+}
+
+// ── Slide exports ─────────────────────────────────────────────────────────────
+
+/** Slide 04 — ArchMap "The full picture" (assembler places this at slot 4) */
+export const archMap: SlideData[] = [
+  {
+    id: 4,
+    acts: 7,
+    title: 'The full picture',
+    content: <ArchMap />,
+    notes:
+      "Three-column layout. Left: the output — a GitHub PR. Centre: Agentic Pipelines — the main loop (Pre Screen, Implementation, Review in a tight cycle) and the After PR loop (Comment Triage, CI Failure response, Fix Verification). Right: what feeds the agent — Contexts (pipeline logs, PR reviews, lint policies) and Playbooks (optimisation strategies like layer caching and step parallelisation).\n\nThe bidirectional arrows between Implementation and Review are the Verification Loop — the agent doesn't just write code, it reviews its own output and iterates before opening a PR.\n\nContexts and Playbooks both point left into the Agentic Pipelines — they're the signal and the rulebook that the agent consults on every cycle.",
+  },
+];
+
+/** Slide 07 — FunnelAnimation "The main loop" (assembler places this at slot 7) */
+export const funnel: SlideData[] = [
+  {
+    id: 7,
+    acts: 7,
+    title: 'The main loop',
+    content: (
+      <div className="flex-1 flex min-h-0 w-full">
+        <FunnelAnimation />
+      </div>
+    ),
+    notes:
+      "The answer to the 'one big agent' failure is a funnel. Not a funnel for performance — though it helps with cost — but a funnel for confidence. Each stage has exactly one job. One output schema. One model choice matched to the difficulty of that job. And each stage can fail in a visible way: the pre-screen says 'no violation' and that decision is logged. The reviewer rejects a diff and you see exactly which rule it failed and why. The funnel makes agent behavior understandable, and understandable behavior is the prerequisite for trust.",
+  },
+];
+
+export default [...archMap, ...funnel];

--- a/src/components/talks/pipeline-optimizer/slides/04-architecture.tsx
+++ b/src/components/talks/pipeline-optimizer/slides/04-architecture.tsx
@@ -460,4 +460,5 @@ export const funnel: SlideData[] = [
   },
 ];
 
-export default [...archMap, ...funnel];
+const slides = [...archMap, ...funnel];
+export default slides;

--- a/src/components/talks/pipeline-optimizer/slides/04b-why-ci.tsx
+++ b/src/components/talks/pipeline-optimizer/slides/04b-why-ci.tsx
@@ -1,0 +1,79 @@
+'use client';
+
+import React from 'react';
+import { motion } from 'framer-motion';
+import type { SlideData } from './_types';
+import { useSlideActs } from '../slide-acts-context';
+import { sans } from '@/lib/fonts';
+
+// ── Slide — Why CI is the right first domain ─────────────────────────────────
+const ciProperties = [
+  {
+    icon: '🛡',
+    title: 'Bounded blast radius',
+    detail: 'Wrong fix breaks CI immediately, visibly, reversibly. Nothing downstream burns.',
+  },
+  {
+    icon: '✅',
+    title: 'Machine-verifiable',
+    detail: 'Did it work? CI pass or fail. Build logs are ground truth — no ambiguity.',
+  },
+  {
+    icon: '🔀',
+    title: 'Human checkpoint',
+    detail: 'Agent opens PRs. A human reviews and merges. The agent cannot merge its own work.',
+  },
+];
+
+function WhyCISlide() {
+  const { act } = useSlideActs();
+
+  const fadeIn = (atAct: number) => ({
+    initial: { opacity: 0, y: 8 },
+    animate: { opacity: act >= atAct ? 1 : 0, y: act >= atAct ? 0 : 8 },
+    transition: { duration: 0.35, ease: 'easeOut' as const },
+  });
+
+  return (
+    <div className="flex flex-col h-full w-full gap-8">
+      <div className="grid grid-cols-3 gap-5 flex-1">
+        {ciProperties.map((p, i) => (
+          <motion.div
+            key={p.title}
+            {...fadeIn(i + 1)}
+            className="border border-white/15 rounded-lg p-6 flex flex-col gap-3"
+          >
+            <div className="text-3xl">{p.icon}</div>
+            <div className={`${sans.className} text-xl text-white font-semibold leading-tight`}>
+              {p.title}
+            </div>
+            <div className={`${sans.className} text-sm text-white/60`}>{p.detail}</div>
+          </motion.div>
+        ))}
+      </div>
+
+      <motion.div {...fadeIn(4)} className="flex flex-col gap-2">
+        <div className="font-mono text-xs text-white/35 uppercase tracking-widest">
+          this is the trust architecture
+        </div>
+        <div className={`${sans.className} text-lg italic text-white/70`}>
+          Trust isn&apos;t &ldquo;it will never be wrong.&rdquo; It&apos;s &ldquo;the failure modes
+          are visible, bounded, and recoverable.&rdquo;
+        </div>
+      </motion.div>
+    </div>
+  );
+}
+
+const slides: SlideData[] = [
+  {
+    id: 9,
+    title: 'Why CI is the right first domain',
+    acts: 5,
+    content: <WhyCISlide />,
+    notes:
+      "There's a reason we started with CI optimization rather than automated code refactoring or infra changes. CI optimization has three properties that make autonomous operation unusually safe. One: the blast radius is bounded. If the optimizer produces a wrong fix, CI breaks immediately. Someone looks at the PR, reverts it, and nothing else is affected. Two: the outcome is machine-verifiable. Does CI pass? Yes or no. There's no ambiguity about whether the optimization worked. The build logs are ground truth. Three: the output is always a pull request, and a human reviews that PR before it merges. The agent cannot merge its own work. Put those three together and you have a domain where you can build trust incrementally — start with high scrutiny, lower it as the track record grows. That architecture is deliberate. It's not just a safety feature. It's how you get from 'this is interesting' to 'I trust this enough to merge without reviewing every line.'",
+  },
+];
+
+export default slides;

--- a/src/components/talks/pipeline-optimizer/slides/04c-playbooks.tsx
+++ b/src/components/talks/pipeline-optimizer/slides/04c-playbooks.tsx
@@ -1,0 +1,293 @@
+'use client';
+
+// Slide 04c — "Playbooks" (definition + principles + examples)
+// Acts: 0=empty  1=definition  2=principles  3=examples
+// Rebuilt per task #94: NOT a catalog grid.
+
+import React from 'react';
+import { motion } from 'framer-motion';
+import {
+  Zap,
+  Key,
+  RefreshCw,
+  BookOpen,
+  Crosshair,
+  Layers,
+  GitPullRequest,
+  BarChart2,
+} from 'lucide-react';
+import type { SlideData } from './_types';
+import { useSlideActs } from '../slide-acts-context';
+import { sans } from '@/lib/fonts';
+
+// ── Brand ─────────────────────────────────────────────────────────────────────
+const TEAL        = 'rgb(0,175,154)';
+const PINK        = 'rgb(255,167,196)';
+const TEAL_BG     = 'rgba(0,175,154,0.08)';
+const TEAL_BORDER = 'rgba(0,175,154,0.22)';
+const PINK_BG     = 'rgba(255,167,196,0.08)';
+const PINK_BORDER = 'rgba(255,167,196,0.22)';
+
+// ── Principles ─────────────────────────────────────────────────────────────────
+// 5 load-bearing principles from the research
+const PRINCIPLES = [
+  { Icon: BookOpen,    label: 'Documented — not in heads' },
+  { Icon: Crosshair,   label: 'Trigger + recipe' },
+  { Icon: Layers,      label: 'Bounded scope' },
+  { Icon: GitPullRequest, label: 'Reversible — ships as PR' },
+  { Icon: BarChart2,   label: 'Evidence-backed' },
+] as const;
+
+// ── Examples ───────────────────────────────────────────────────────────────────
+const EXAMPLES = [
+  {
+    Icon: Zap,
+    title: 'Parallelize test steps',
+    tag: 'parallelization',
+  },
+  {
+    Icon: Key,
+    title: 'Cache key includes lockfile hash',
+    tag: 'standard',
+  },
+  {
+    Icon: RefreshCw,
+    title: 'Retry budget on flaky steps',
+    tag: 'reliability',
+  },
+] as const;
+
+// ── PrincipleChip ─────────────────────────────────────────────────────────────
+function PrincipleChip({
+  Icon,
+  label,
+  visible,
+  delay,
+}: {
+  Icon: React.ElementType;
+  label: string;
+  visible: boolean;
+  delay: number;
+}) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 6 }}
+      animate={{ opacity: visible ? 1 : 0, y: visible ? 0 : 6 }}
+      transition={{ duration: 0.25, ease: 'easeOut', delay: visible ? delay : 0 }}
+      style={{
+        display: 'inline-flex',
+        alignItems: 'center',
+        gap: 7,
+        background: TEAL_BG,
+        border: `1px solid ${TEAL_BORDER}`,
+        borderRadius: 999,
+        padding: '7px 14px',
+        whiteSpace: 'nowrap',
+      }}
+    >
+      <Icon size={13} color={TEAL} strokeWidth={2} style={{ flexShrink: 0 }} />
+      <span
+        style={{
+          fontSize: 13,
+          fontWeight: 600,
+          color: 'rgba(255,255,255,0.85)',
+          letterSpacing: '-0.01em',
+        }}
+      >
+        {label}
+      </span>
+    </motion.div>
+  );
+}
+
+// ── ExampleCard ───────────────────────────────────────────────────────────────
+function ExampleCard({
+  Icon,
+  title,
+  tag,
+  visible,
+  delay,
+}: {
+  Icon: React.ElementType;
+  title: string;
+  tag: string;
+  visible: boolean;
+  delay: number;
+}) {
+  return (
+    <motion.div
+      initial={{ opacity: 0, y: 10 }}
+      animate={{ opacity: visible ? 1 : 0, y: visible ? 0 : 10 }}
+      transition={{ duration: 0.3, ease: 'easeOut', delay: visible ? delay : 0 }}
+      style={{
+        flex: 1,
+        background: PINK_BG,
+        border: `1px solid ${PINK_BORDER}`,
+        borderRadius: 10,
+        padding: '14px 16px',
+        display: 'flex',
+        flexDirection: 'column',
+        gap: 8,
+      }}
+    >
+      <Icon size={18} color={PINK} strokeWidth={2} />
+      <div
+        style={{
+          fontSize: 13.5,
+          fontWeight: 700,
+          color: 'rgba(255,255,255,0.90)',
+          lineHeight: 1.35,
+          letterSpacing: '-0.01em',
+        }}
+      >
+        {title}
+      </div>
+      <div
+        style={{
+          fontSize: 10.5,
+          color: 'rgba(255,255,255,0.35)',
+          fontFamily: 'ui-monospace,monospace',
+          letterSpacing: '0.03em',
+        }}
+      >
+        {tag}
+      </div>
+    </motion.div>
+  );
+}
+
+// ── Divider ───────────────────────────────────────────────────────────────────
+function Divider({ visible }: { visible: boolean }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: visible ? 1 : 0 }}
+      transition={{ duration: 0.2 }}
+      style={{
+        height: 1,
+        background: 'rgba(255,255,255,0.07)',
+        margin: '2px 0',
+      }}
+    />
+  );
+}
+
+// ── SectionLabel ──────────────────────────────────────────────────────────────
+function SectionLabel({ children, visible }: { children: React.ReactNode; visible: boolean }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: visible ? 1 : 0 }}
+      transition={{ duration: 0.2 }}
+      style={{
+        fontSize: 10,
+        fontWeight: 700,
+        letterSpacing: '0.12em',
+        textTransform: 'uppercase' as const,
+        color: TEAL,
+        marginBottom: 6,
+      }}
+    >
+      {children}
+    </motion.div>
+  );
+}
+
+// ── Main slide component ──────────────────────────────────────────────────────
+function PlaybooksSlide() {
+  const { act } = useSlideActs();
+
+  const showDefinition = act >= 1;
+  const showPrinciples = act >= 2;
+  const showExamples   = act >= 3;
+
+  return (
+    <div
+      className={`${sans.className} flex flex-col h-full w-full`}
+      style={{ gap: 20, paddingBottom: 4 }}
+    >
+      {/* ── Section 1: Definition ─────────────────────────────────────────────── */}
+      <motion.div
+        initial={{ opacity: 0, y: 10 }}
+        animate={{ opacity: showDefinition ? 1 : 0, y: showDefinition ? 0 : 10 }}
+        transition={{ duration: 0.35, ease: 'easeOut' }}
+      >
+        <SectionLabel visible={showDefinition}>What's a playbook?</SectionLabel>
+        <div
+          style={{
+            fontSize: 19,
+            fontWeight: 600,
+            color: 'rgba(255,255,255,0.90)',
+            lineHeight: 1.5,
+            letterSpacing: '-0.02em',
+          }}
+        >
+          A documented optimization pattern — a{' '}
+          <span style={{ color: TEAL, fontWeight: 700 }}>trigger condition</span>{' '}
+          the agent checks for, and a{' '}
+          <span style={{ color: TEAL, fontWeight: 700 }}>fix recipe</span>{' '}
+          it applies when the trigger fires.
+        </div>
+      </motion.div>
+
+      {/* ── Divider ───────────────────────────────────────────────────────────── */}
+      <Divider visible={showPrinciples} />
+
+      {/* ── Section 2: Principles ─────────────────────────────────────────────── */}
+      <div>
+        <SectionLabel visible={showPrinciples}>Principles</SectionLabel>
+        <div
+          style={{
+            display: 'flex',
+            flexWrap: 'wrap',
+            gap: 8,
+          }}
+        >
+          {PRINCIPLES.map(({ Icon, label }, i) => (
+            <PrincipleChip
+              key={label}
+              Icon={Icon}
+              label={label}
+              visible={showPrinciples}
+              delay={i * 0.055}
+            />
+          ))}
+        </div>
+      </div>
+
+      {/* ── Divider ───────────────────────────────────────────────────────────── */}
+      <Divider visible={showExamples} />
+
+      {/* ── Section 3: Examples ───────────────────────────────────────────────── */}
+      <div>
+        <SectionLabel visible={showExamples}>Examples</SectionLabel>
+        <div style={{ display: 'flex', gap: 12 }}>
+          {EXAMPLES.map(({ Icon, title, tag }, i) => (
+            <ExampleCard
+              key={title}
+              Icon={Icon}
+              title={title}
+              tag={tag}
+              visible={showExamples}
+              delay={i * 0.07}
+            />
+          ))}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Slide export ──────────────────────────────────────────────────────────────
+const playbookSlides: SlideData[] = [
+  {
+    id: 17,
+    title: 'Playbooks',
+    acts: 4,
+    content: <PlaybooksSlide />,
+    notes:
+      "A playbook is a documented optimization pattern — a named trigger condition and a fix recipe. The agent reads the playbook to know what to look for and exactly how to fix it.\n\nFive principles make a playbook good: it must be documented (not tribal knowledge), it must have a clear trigger and recipe, it must have bounded scope (one focused fix), it must be reversible (ships as a PR that humans can reject), and it must be evidence-backed (we have baseline data to measure the win).\n\nThree examples from the working set: parallelize test steps, make cache keys include lockfile hashes so they auto-invalidate, and set a retry budget on flaky steps so CI noise is bounded.\n\nThe catalog has twelve today. Each one started as a human observation — 'we keep doing this manually.' The playbook format is how you turn that observation into something an agent can act on autonomously.",
+  },
+];
+
+export default playbookSlides;

--- a/src/components/talks/pipeline-optimizer/slides/04c-playbooks.tsx
+++ b/src/components/talks/pipeline-optimizer/slides/04c-playbooks.tsx
@@ -212,7 +212,7 @@ function PlaybooksSlide() {
         animate={{ opacity: showDefinition ? 1 : 0, y: showDefinition ? 0 : 10 }}
         transition={{ duration: 0.35, ease: 'easeOut' }}
       >
-        <SectionLabel visible={showDefinition}>What's a playbook?</SectionLabel>
+        <SectionLabel visible={showDefinition}>What&apos;s a playbook?</SectionLabel>
         <div
           style={{
             fontSize: 19,

--- a/src/components/talks/pipeline-optimizer/slides/04d-vs-alternatives.tsx
+++ b/src/components/talks/pipeline-optimizer/slides/04d-vs-alternatives.tsx
@@ -1,0 +1,142 @@
+'use client';
+
+import React from 'react';
+import { motion } from 'framer-motion';
+import type { SlideData } from './_types';
+import { useSlideActs } from '../slide-acts-context';
+import { sans } from '@/lib/fonts';
+
+// ── Slide — vs. general agents ────────────────────────────────────────────────
+
+const TEAL = 'rgb(0,175,154)';
+const PINK = 'rgb(255,167,196)';
+
+const axes = ['Control', 'Customization', 'Context', 'Verification'];
+
+const rows = [
+  {
+    label: 'Devin',
+    cells: ['Single agent · re-runs fixes', 'Plugin limits', 'Generic browsing', 'Self-assessed + CI'],
+    highlight: false,
+  },
+  {
+    label: 'Claude routines',
+    cells: ['Single agent · re-runs fixes', 'Prompt + tools', 'You paste it', 'Self-assessed + CI'],
+    highlight: false,
+  },
+  {
+    label: 'Ours',
+    cells: ['Multi-agent + run dedup', 'Custom MCPs', 'Anything we wire in', 'CI + AI review + agent verify'],
+    highlight: true,
+  },
+];
+
+function VsAlternativesSlide() {
+  const { act } = useSlideActs();
+
+  const fadeIn = (atAct: number) => ({
+    initial: { opacity: 0, y: 6 },
+    animate: { opacity: act >= atAct ? 1 : 0, y: act >= atAct ? 0 : 6 },
+    transition: { duration: 0.3, ease: 'easeOut' as const },
+  });
+
+  return (
+    <div className="flex flex-col h-full w-full gap-6">
+      {/* Table */}
+      <div className="flex-1 flex flex-col min-h-0">
+        {/* Axis header row */}
+        <div className="grid grid-cols-5 mb-2 px-1">
+          <div />
+          {axes.map((axis) => (
+            <div
+              key={axis}
+              className={`${sans.className} text-xs uppercase tracking-widest font-semibold text-center pb-2`}
+              style={{ color: TEAL }}
+            >
+              {axis}
+            </div>
+          ))}
+        </div>
+
+        {/* Divider */}
+        <div className="border-t border-white/10 mb-3" />
+
+        {/* Data rows */}
+        <div className="flex flex-col gap-3 flex-1">
+          {rows.map((row, i) => (
+            <motion.div
+              key={row.label}
+              {...fadeIn(i + 1)}
+              className="grid grid-cols-5 rounded-xl overflow-hidden"
+              style={{
+                border: row.highlight
+                  ? `1.5px solid ${TEAL}`
+                  : '1px solid rgba(255,255,255,0.1)',
+                background: row.highlight
+                  ? 'rgba(0,175,154,0.08)'
+                  : 'rgba(255,255,255,0.03)',
+              }}
+            >
+              {/* Row label */}
+              <div
+                className={`${sans.className} flex items-center px-5 py-5 text-sm font-semibold`}
+                style={{ color: row.highlight ? TEAL : 'rgba(255,255,255,0.6)' }}
+              >
+                {row.label}
+              </div>
+
+              {/* Cells */}
+              {row.cells.map((cell, j) => {
+                const isNegative = cell === 'Self-assessed + CI' || cell === 'Generic browsing';
+                const cellColor = row.highlight
+                  ? 'rgba(255,255,255,0.9)'
+                  : isNegative
+                  ? PINK
+                  : 'rgba(255,255,255,0.55)';
+
+                return (
+                  <div
+                    key={j}
+                    className={`${sans.className} flex items-center justify-center px-3 py-5 text-sm text-center leading-snug`}
+                    style={{
+                      borderLeft: '1px solid rgba(255,255,255,0.07)',
+                      color: cellColor,
+                    }}
+                  >
+                    {cell}
+                  </div>
+                );
+              })}
+            </motion.div>
+          ))}
+        </div>
+      </div>
+
+      {/* Punchline */}
+      <motion.div {...fadeIn(4)} className="pt-3 border-t border-white/10">
+        <div className="font-mono text-xs text-white/35 uppercase tracking-widest mb-1">
+          the unlock
+        </div>
+        <div
+          className={`${sans.className} text-xl font-semibold`}
+          style={{ color: TEAL }}
+        >
+          Control was the unlock — specificity beats generality.
+        </div>
+      </motion.div>
+    </div>
+  );
+}
+
+const slides: SlideData[] = [
+  {
+    id: 18,
+    title: 'vs. general agents',
+    acts: 5,
+    content: <VsAlternativesSlide />,
+    notes:
+      "Why not just use Devin automations or Claude routines? They both run agents on a schedule — so what's the difference? Control is the axis that matters. Devin gives you vendor-defined behavior: you can configure plugins, but the agent's judgment and context are opaque. Claude routines give you prompt-level control — better, but the agent only knows what you paste in. Our agent is different on every axis: per-stage playbooks define exactly what each sub-agent does; custom MCP tools give it exactly the right tool surface; and Buildkite data plus repo knowledge is injected automatically — no pasting required. The biggest difference is verification. The alternatives self-assess: the agent decides whether it succeeded. Ours re-runs CI, reads AI review comments, and confirms the fix actually worked before closing the loop. That specificity is what earns trust fast enough to scale. We didn't pick a general agent and prompt-engineer our way to safety. We built something narrow enough to be right.",
+  },
+];
+
+export default slides;

--- a/src/components/talks/pipeline-optimizer/slides/05-key-insight.tsx
+++ b/src/components/talks/pipeline-optimizer/slides/05-key-insight.tsx
@@ -1,0 +1,189 @@
+// porter-B: slides/05-key-insight.md → slide Learning #2
+import React from 'react';
+import { motion } from 'framer-motion';
+import type { SlideData } from './_types';
+import { useSlideActs } from '../slide-acts-context';
+import { sans } from '@/lib/fonts';
+
+// ── Slide — Learning #2: One custom tool, not a chain of MCP calls ────────────
+// BEFORE: 4 generic MCP calls just to get logs for one failed step.
+// AFTER:  1 purpose-built tool replaces the chain.
+
+// Four arrows fanning from a center dot in the "before" panel.
+const BEFORE_ARROWS = [
+  { d: 'M 150 100 L 55 28', delay: 0 },
+  { d: 'M 150 100 L 245 28', delay: 0.13 },
+  { d: 'M 150 100 L 55 172', delay: 0.26 },
+  { d: 'M 150 100 L 245 172', delay: 0.39 },
+];
+
+function CustomToolVisual() {
+  const { act } = useSlideActs();
+
+  const fadeIn = (atAct: number) => ({
+    initial: { opacity: 0, y: 8 },
+    animate: { opacity: act >= atAct ? 1 : 0, y: act >= atAct ? 0 : 8 },
+    transition: { duration: 0.35, ease: 'easeOut' as const },
+  });
+
+  return (
+    <div className="flex flex-col h-full w-full gap-6">
+      <div className="grid grid-cols-2 gap-8 flex-1 min-h-0">
+        {/* ── BEFORE column ── */}
+        <motion.div
+          {...fadeIn(1)}
+          className="border border-white/15 rounded-lg p-6 flex flex-col items-center justify-between"
+        >
+          <div className="font-mono text-xs uppercase tracking-widest text-white/40">Before</div>
+
+          {/* SVG: center dot + 4 arrows fanning out */}
+          <div className="relative w-full flex-1 flex items-center justify-center">
+            <svg viewBox="0 0 300 200" className="w-full h-full">
+              <defs>
+                <marker
+                  id="ct-ah-before"
+                  viewBox="0 0 10 10"
+                  refX="9"
+                  refY="5"
+                  markerWidth="6"
+                  markerHeight="6"
+                  orient="auto"
+                >
+                  <path d="M 0 0 L 10 5 L 0 10 z" fill="rgba(255,255,255,0.5)" />
+                </marker>
+              </defs>
+
+              {/* center dot */}
+              <circle cx="150" cy="100" r="8" fill="rgba(255,255,255,0.6)" />
+
+              {/* 4 fanning arrows — staggered pathLength */}
+              {BEFORE_ARROWS.map((arrow, i) => (
+                <motion.path
+                  key={i}
+                  d={arrow.d}
+                  stroke="rgba(255,255,255,0.5)"
+                  strokeWidth="2"
+                  fill="none"
+                  markerEnd="url(#ct-ah-before)"
+                  initial={{ pathLength: 0, opacity: 0 }}
+                  animate={{
+                    pathLength: act >= 1 ? 1 : 0,
+                    opacity: act >= 1 ? 1 : 0,
+                  }}
+                  transition={{
+                    pathLength: {
+                      duration: 0.5,
+                      delay: act >= 1 ? arrow.delay : 0,
+                      ease: 'easeOut',
+                    },
+                    opacity: { duration: 0.15, delay: act >= 1 ? arrow.delay : 0 },
+                  }}
+                />
+              ))}
+
+              {/* tool labels at arrow endpoints */}
+              <text x="55"  y="18"  fontSize="10" fill="rgba(255,255,255,0.45)" textAnchor="middle" fontFamily="monospace">list_pipelines</text>
+              <text x="245" y="18"  fontSize="10" fill="rgba(255,255,255,0.45)" textAnchor="middle" fontFamily="monospace">list_builds</text>
+              <text x="55"  y="190" fontSize="10" fill="rgba(255,255,255,0.45)" textAnchor="middle" fontFamily="monospace">get_build</text>
+              <text x="245" y="190" fontSize="10" fill="rgba(255,255,255,0.45)" textAnchor="middle" fontFamily="monospace">get_step_logs</text>
+            </svg>
+          </div>
+
+          <div className="font-mono text-xs text-white/40 mt-2 text-center">
+            4 calls just to fetch logs for one step
+          </div>
+        </motion.div>
+
+        {/* ── AFTER column ── */}
+        <motion.div
+          {...fadeIn(2)}
+          className="border rounded-lg p-6 flex flex-col items-center justify-between"
+          style={{ borderColor: 'rgba(0,175,154,0.4)' }}
+        >
+          <div
+            className="font-mono text-xs uppercase tracking-widest"
+            style={{ color: 'rgb(0,175,154)' }}
+          >
+            After
+          </div>
+
+          {/* SVG: center dot + single arrow down */}
+          <div className="relative w-full flex-1 flex items-center justify-center">
+            <svg viewBox="0 0 300 200" className="w-full h-full">
+              <defs>
+                <marker
+                  id="ct-ah-after"
+                  viewBox="0 0 10 10"
+                  refX="9"
+                  refY="5"
+                  markerWidth="6"
+                  markerHeight="6"
+                  orient="auto"
+                >
+                  <path d="M 0 0 L 10 5 L 0 10 z" fill="rgba(0,175,154,0.8)" />
+                </marker>
+              </defs>
+
+              <circle cx="150" cy="60" r="8" fill="rgba(0,175,154,0.8)" />
+
+              {/* one arrow straight down */}
+              <motion.path
+                d="M 150 75 L 150 130"
+                stroke="rgba(0,175,154,0.8)"
+                strokeWidth="2.5"
+                fill="none"
+                markerEnd="url(#ct-ah-after)"
+                initial={{ pathLength: 0, opacity: 0 }}
+                animate={{
+                  pathLength: act >= 2 ? 1 : 0,
+                  opacity: act >= 2 ? 1 : 0,
+                }}
+                transition={{
+                  pathLength: { duration: 0.5, ease: 'easeOut' },
+                  opacity: { duration: 0.15 },
+                }}
+              />
+
+              {/* function name */}
+              <text
+                x="150"
+                y="158"
+                fontSize="11"
+                fill="rgba(255,255,255,0.85)"
+                textAnchor="middle"
+                fontFamily="monospace"
+              >
+                get_step_logs_for_branch
+              </text>
+            </svg>
+          </div>
+
+          <div className="font-mono text-xs text-white/50 mt-2">
+            1 call · purpose-built · tight schema
+          </div>
+        </motion.div>
+      </div>
+
+      {/* tagline */}
+      <motion.div
+        {...fadeIn(3)}
+        className={`${sans.className} text-xl text-white/70 italic text-center mt-2`}
+      >
+        &ldquo;shape the API to the consumer, not the upstream&rdquo;
+      </motion.div>
+    </div>
+  );
+}
+
+const slides: SlideData[] = [
+  {
+    id: 10,
+    title: 'Learning #2: One custom tool, not a chain of MCP calls',
+    acts: 4,
+    content: <CustomToolVisual />,
+    notes:
+      "We started by giving each agent the Buildkite MCP — Buildkite's official tool surface, with about ten methods. The agent could call any of them. And to do one logical thing — like \"get the logs for this failing step\" — it had to chain four of them: list the pipelines, then list the builds, then get the build, then get the step logs. Four decisions. Four round-trips. Four chances to go off-script.\n\nSo we wrote one custom tool that does that whole chain internally. The agent now calls `get_step_logs_for_branch` once. It gets a single aggregated response shaped for what it actually needs to do. One decision. One round-trip.\n\nThe second half of this principle is about the response shape. The Buildkite MCP returns generic schemas — fields for every possible consumer, of which the agent reads maybe a quarter. Every field that goes into the context costs tokens, and worse, every field is a decision the agent might branch on. If a field exists in the response, the agent might cite it, weigh it, get confused by it. Our custom tool returns only what the agent uses to do its job — the failed step, the relevant log lines, the playbook rule. Tight schema. Nothing extra. The agent has less to read and fewer ways to wander.\n\nThe principle: shape the API to the consumer, not the upstream. The \"consumer\" is the agent. Each category of agent need becomes one of our purpose-built tools that wraps several upstream MCP calls and trims the response.\n\nThe reviewer takes this to its limit — zero MCP at all. The principle scales: every upstream tool you wrap is a decision you remove from the agent. Smaller surface, fewer wrong moves, cheaper context, narrower blast radius.",
+  },
+];
+
+export default slides;

--- a/src/components/talks/pipeline-optimizer/slides/06-demo.tsx
+++ b/src/components/talks/pipeline-optimizer/slides/06-demo.tsx
@@ -1,0 +1,60 @@
+// porter-C: slides/06-demo.md → slide 13
+import React from 'react';
+import type { SlideData } from './_types';
+
+// TODO(slide-designer): Decision needed — live demo, recorded, or 4-panel static walkthrough.
+//   See 06-demo.md for all three options. Static fallback below.
+// TODO(tulsi): Confirm demo format before the talk. Record or prepare 4-panel fallback.
+interface JourneyTile {
+  label: string;
+  body: string;
+}
+
+const journeyTiles: JourneyTile[] = [
+  {
+    label: '① Pre-screen · Haiku',
+    body: `→ violationPresent: true\n   reason: "No artifact cache configured\n            for the npm install step.\n            Median step duration: 3m 42s."`,
+  },
+  {
+    label: '② Implementation diff',
+    body: `+ - label: "Cache restore"\n+   plugins:\n+     cache#v1.4.0:\n+       key: "npm-{{ checksum \\"package-lock.json\\" }}"\n+       paths: [ "node_modules" ]`,
+  },
+  {
+    label: '③ Reviewer · Haiku',
+    body: `findings: []\npass: true\n\n→ No error-severity findings.\n  Pipeline proceeds to PR creation.`,
+  },
+  {
+    label: '④ Resulting PR',
+    body: `Title: "feat(ci): add npm cache to install step"\n\nEstimated saving: ~3m 30s per build\nVerification: CI logs should show "Cache hit"`,
+  },
+];
+
+const slides: SlideData[] = [
+  {
+    id: 11,
+    title: "End-to-end: one PR's journey",
+    content: (
+      <div className="grid grid-cols-2 gap-3 mt-2 text-sm h-full w-full">
+        {journeyTiles.map(({ label, body }) => (
+          <div key={label} className="border border-white/10 rounded p-3">
+            <div className="font-mono text-[10px] text-white/40 uppercase tracking-widest mb-2">
+              {label}
+            </div>
+            <pre className="font-mono text-xs text-white/75 whitespace-pre-wrap leading-relaxed">
+              {body}
+            </pre>
+          </div>
+        ))}
+        <div className="col-span-2 mt-1">
+          <p className="font-mono text-sm text-white/50 text-center">
+            &ldquo;At no point in that sequence did I write anything.&rdquo;
+          </p>
+        </div>
+      </div>
+    ),
+    notes:
+      "Walk the audience through each stage as it runs. When the pre-screen outputs 'violationPresent: true,' say: 'That's the gate. This repo needs the fix. Sonnet gets called.' When the reviewer outputs its findings (or no findings), say: 'No blocking findings. The diff passes.' When the PR appears: 'That PR is now in the repo owner's inbox. I didn't write it. I didn't review it before it went out. The system reviewed it.' The key moment is the PR description — read the estimated saving line out loud, then: 'The agent computed that estimate from actual build log data, not from a formula. After the PR merges, a verification job checks whether those log patterns actually appear in the next CI run. Not we think it saved 3 minutes. We confirmed it saved 3 minutes.' Universal closing beat: 'At no point in that sequence did I write anything. I set up the playbook rule, I configured the service, and then I went to sleep. The funnel ran overnight. That's what the first slide was about.'",
+  },
+];
+
+export default slides;

--- a/src/components/talks/pipeline-optimizer/slides/06b-feedback-loop.tsx
+++ b/src/components/talks/pipeline-optimizer/slides/06b-feedback-loop.tsx
@@ -1,0 +1,650 @@
+'use client';
+
+// Slide — Verification Loop: GitHub PR conversation timeline.
+// Progressive reveal via useSlideActs(), 9 acts (0-8).
+// Story: agent PR fails CI → agent self-corrects → CI passes → cursor[bot] code review → agent resolves → agent verification → merged.
+// Sanitized: no internal repo names, no real handles, no real bot account names.
+
+import React from 'react';
+import { motion, AnimatePresence } from 'framer-motion';
+import { Check, X, GitMerge, GitCommit, Loader2 } from 'lucide-react';
+import type { SlideData } from './_types';
+import { useSlideActs } from '../slide-acts-context';
+import { sans } from '@/lib/fonts';
+
+// ── Brand ────────────────────────────────────────────────────────────────────
+const SLIDE_BG    = '#1c1e26'; // slide content background — used to mask timeline line
+const TEAL        = 'rgb(0,175,154)';
+const TEAL_BG     = 'rgba(0,175,154,0.10)';
+const TEAL_BORDER = 'rgba(0,175,154,0.40)';
+const PINK        = 'rgb(255,167,196)';
+const PINK_BORDER = 'rgba(255,167,196,0.40)';
+const BLUE        = 'rgb(88,166,255)';
+const BLUE_BORDER = 'rgba(88,166,255,0.35)';
+const PURPLE      = 'rgb(163,113,247)';
+const PURPLE_BG   = 'rgba(163,113,247,0.10)';
+const PURPLE_BDR  = 'rgba(163,113,247,0.35)';
+const CARD_BG     = '#161b22';
+const EDGE        = '#30363d';
+const TEXT        = 'rgba(255,255,255,0.88)';
+const MUTED       = 'rgba(255,255,255,0.45)';
+const GHOST       = 'rgba(255,255,255,0.22)';
+
+// ── Animation helpers ────────────────────────────────────────────────────────
+const ENTER = {
+  initial: { opacity: 0, y: 7 },
+  animate: { opacity: 1, y: 0 },
+  exit:    { opacity: 0, transition: { duration: 0.12 } },
+  transition: { duration: 0.32, ease: 'easeOut' as const },
+};
+
+// ── Avatar ────────────────────────────────────────────────────────────────────
+function Avatar({
+  initials,
+  color = TEAL,
+  size = 24,
+}: {
+  initials: string;
+  color?: string;
+  size?: number;
+}) {
+  return (
+    <div
+      style={{
+        width: size,
+        height: size,
+        borderRadius: '50%',
+        background: color.replace('rgb', 'rgba').replace(')', ', 0.14)'),
+        border: `1.5px solid ${color}`,
+        display: 'flex',
+        alignItems: 'center',
+        justifyContent: 'center',
+        fontSize: Math.round(size * 0.37),
+        fontFamily: 'monospace',
+        color,
+        fontWeight: 700,
+        flexShrink: 0,
+        lineHeight: 1,
+        position: 'relative',
+        zIndex: 1,
+        boxShadow: `0 0 0 3px ${SLIDE_BG}`,
+      }}
+    >
+      {initials}
+    </div>
+  );
+}
+
+// ── PR Header Card ────────────────────────────────────────────────────────────
+function PRHeaderCard() {
+  return (
+    <div style={{ display: 'flex', gap: 8, alignItems: 'flex-start' }}>
+      <Avatar initials="PO" color={TEAL} size={24} />
+      <div
+        style={{
+          flex: 1,
+          background: CARD_BG,
+          border: `1px solid ${EDGE}`,
+          borderLeft: `3px solid ${TEAL_BORDER}`,
+          borderRadius: '0 8px 8px 0',
+          padding: '12px 16px',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 7,
+          minWidth: 0,
+        }}
+      >
+        <div style={{ display: 'flex', alignItems: 'center', gap: 7, flexWrap: 'wrap' }}>
+          <span style={{ fontFamily: 'monospace', fontSize: 11, color: MUTED }}>
+            pipeline-optimizer-agent[bot]
+          </span>
+          <span style={{ fontSize: 11, color: GHOST }}>opened this pull request</span>
+          <span
+            style={{
+              marginLeft: 'auto',
+              background: TEAL_BG,
+              border: `1px solid ${TEAL_BORDER}`,
+              borderRadius: 12,
+              padding: '2px 9px',
+              fontSize: 11,
+              fontFamily: 'monospace',
+              color: TEAL,
+              fontWeight: 600,
+            }}
+          >
+            Open
+          </span>
+        </div>
+
+        <div style={{ fontSize: 15, fontWeight: 700, color: TEXT, lineHeight: 1.35 }}>
+          Enable cache plugin on build pipeline
+        </div>
+
+        <div
+          style={{
+            fontFamily: 'monospace',
+            fontSize: 10.5,
+            color: MUTED,
+            lineHeight: 1.55,
+            borderTop: `1px solid ${EDGE}`,
+            paddingTop: 7,
+          }}
+        >
+          Applies <span style={{ color: TEXT }}>cache-buildkite-plugin</span> to the unit-test step in{' '}
+          <span style={{ color: TEXT }}>.buildkite/pipeline.yml</span>.
+          &nbsp;Estimated savings: 30–60s per warm cache hit.
+          <br />
+          <span style={{ color: GHOST }}>Co-authored-by: Claude Sonnet &lt;noreply@anthropic.com&gt;</span>
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── CI Status Row ──────────────────────────────────────────────────────────────
+type CIStatus = 'running' | 'success' | 'failure';
+
+function CIRow({
+  status,
+  runLabel,
+  duration,
+}: {
+  status: CIStatus;
+  runLabel: string;
+  duration?: string;
+}) {
+  const isRunning = status === 'running';
+  const isSuccess = status === 'success';
+  const accentColor = isRunning ? GHOST : isSuccess ? TEAL : PINK;
+  const leftBorder = isRunning
+    ? `1px solid ${EDGE}`
+    : isSuccess
+    ? `1px solid ${EDGE}`
+    : `3px solid ${PINK_BORDER}`;
+
+  return (
+    <div
+      style={{
+        background: CARD_BG,
+        border: `1px solid ${EDGE}`,
+        borderLeft: leftBorder,
+        borderRadius: 6,
+        padding: '9px 14px',
+        display: 'flex',
+        alignItems: 'center',
+        gap: 8,
+        marginLeft: 34,
+      }}
+    >
+      {isRunning ? (
+        <Loader2
+          size={13}
+          color={GHOST}
+          strokeWidth={2}
+          className="animate-spin"
+          style={{ flexShrink: 0 }}
+        />
+      ) : isSuccess ? (
+        <Check size={13} color={TEAL} strokeWidth={2.5} style={{ flexShrink: 0 }} />
+      ) : (
+        <X size={13} color={PINK} strokeWidth={2.5} style={{ flexShrink: 0 }} />
+      )}
+
+      <span style={{ fontFamily: 'monospace', fontSize: 10.5, color: MUTED }}>buildkite</span>
+      <span style={{ fontFamily: 'monospace', fontSize: 10.5, color: TEXT }}>{runLabel}</span>
+
+      {duration && (
+        <span style={{ fontFamily: 'monospace', fontSize: 10, color: accentColor }}>
+          · {duration}
+        </span>
+      )}
+
+      <span
+        style={{
+          marginLeft: 'auto',
+          fontFamily: 'monospace',
+          fontSize: 10,
+          color: accentColor,
+          opacity: isRunning ? 0.5 : 1,
+        }}
+      >
+        {isRunning ? 'In progress…' : 'Details'}
+      </span>
+    </div>
+  );
+}
+
+// ── Comment Card ──────────────────────────────────────────────────────────────
+function CommentCard({
+  initials,
+  handle,
+  timestamp,
+  leftBorderColor = GHOST,
+  avatarColor = TEAL,
+  resolved = false,
+  badge,
+  children,
+}: {
+  initials: string;
+  handle: string;
+  timestamp: string;
+  leftBorderColor?: string;
+  avatarColor?: string;
+  resolved?: boolean;
+  badge?: string;
+  children: React.ReactNode;
+}) {
+  return (
+    <div style={{ display: 'flex', gap: 10, alignItems: 'flex-start' }}>
+      <Avatar initials={initials} color={avatarColor} size={24} />
+      <div
+        style={{
+          flex: 1,
+          background: CARD_BG,
+          border: `1px solid ${EDGE}`,
+          borderLeft: `3px solid ${resolved ? TEAL_BORDER : leftBorderColor}`,
+          borderRadius: '0 6px 6px 0',
+          padding: '11px 15px',
+          minWidth: 0,
+          opacity: resolved ? 0.65 : 1,
+          transition: 'opacity 0.3s ease, border-left-color 0.3s ease',
+        }}
+      >
+        <div style={{ display: 'flex', gap: 7, alignItems: 'center', marginBottom: 5 }}>
+          <span style={{ fontFamily: 'monospace', fontSize: 11, color: TEXT, fontWeight: 600 }}>
+            {handle}
+          </span>
+          <span style={{ fontFamily: 'monospace', fontSize: 10, color: GHOST }}>
+            {timestamp}
+          </span>
+          {resolved && (
+            <span
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 3,
+                background: TEAL_BG,
+                border: `1px solid ${TEAL_BORDER}`,
+                borderRadius: 10,
+                padding: '1px 6px',
+                fontSize: 9,
+                color: TEAL,
+                fontWeight: 600,
+                marginLeft: 2,
+              }}
+            >
+              <Check size={7} strokeWidth={3} />
+              Resolved
+            </span>
+          )}
+          {badge && !resolved && (
+            <span
+              style={{
+                display: 'inline-flex',
+                alignItems: 'center',
+                gap: 3,
+                background: TEAL_BG,
+                border: `1px solid ${TEAL_BORDER}`,
+                borderRadius: 10,
+                padding: '1px 6px',
+                fontSize: 9,
+                color: TEAL,
+                fontWeight: 600,
+                marginLeft: 2,
+              }}
+            >
+              <Check size={7} strokeWidth={3} />
+              {badge}
+            </span>
+          )}
+        </div>
+        <div style={{ fontFamily: 'monospace', fontSize: 11, color: TEXT, lineHeight: 1.6 }}>
+          {children}
+        </div>
+      </div>
+    </div>
+  );
+}
+
+// ── Commit Push Row ───────────────────────────────────────────────────────────
+function CommitPushRow({ hash, message }: { hash: string; message: string }) {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 10,
+        fontFamily: 'monospace',
+        fontSize: 10,
+        color: GHOST,
+      }}
+    >
+      <div
+        style={{
+          width: 24,
+          height: 24,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+          borderRadius: '50%',
+          background: SLIDE_BG,
+          position: 'relative',
+          zIndex: 1,
+        }}
+      >
+        <GitCommit size={18} color={GHOST} />
+      </div>
+      <span>pipeline-optimizer-agent[bot]</span>
+      <span style={{ color: MUTED }}>pushed</span>
+      <span
+        style={{
+          color: TEAL,
+          background: TEAL_BG,
+          border: `1px solid ${TEAL_BORDER}`,
+          padding: '1px 5px',
+          borderRadius: 3,
+          fontWeight: 600,
+        }}
+      >
+        {hash}
+      </span>
+      <span style={{ color: MUTED }}>·</span>
+      <span style={{ color: TEXT }}>{message}</span>
+    </div>
+  );
+}
+
+// ── Merge Badge ───────────────────────────────────────────────────────────────
+function MergeBadge() {
+  return (
+    <div
+      style={{
+        display: 'flex',
+        alignItems: 'center',
+        gap: 9,
+        paddingLeft: 2,
+      }}
+    >
+      {/* Purple merge icon circle */}
+      <div
+        style={{
+          width: 24,
+          height: 24,
+          borderRadius: '50%',
+          background: SLIDE_BG,
+          border: `1.5px solid ${PURPLE_BDR}`,
+          display: 'flex',
+          alignItems: 'center',
+          justifyContent: 'center',
+          flexShrink: 0,
+          position: 'relative',
+          zIndex: 1,
+          boxShadow: `0 0 0 3px ${SLIDE_BG}`,
+        }}
+      >
+        <GitMerge size={12} color={PURPLE} strokeWidth={2.2} />
+      </div>
+
+      {/* Inline sentence */}
+      <span style={{ fontFamily: 'monospace', fontSize: 11, color: MUTED, lineHeight: 1.4 }}>
+        <span style={{ color: TEXT, fontWeight: 600 }}>John Doe</span>
+        {' '}merged commit{' '}
+        <span
+          style={{
+            color: PURPLE,
+            background: PURPLE_BG,
+            border: `1px solid ${PURPLE_BDR}`,
+            padding: '1px 5px',
+            borderRadius: 3,
+            fontWeight: 700,
+          }}
+        >
+          abc1234
+        </span>
+        {' '}into{' '}
+        <span
+          style={{
+            color: MUTED,
+            background: 'rgba(255,255,255,0.06)',
+            border: `1px solid ${EDGE}`,
+            padding: '1px 6px',
+            borderRadius: 3,
+          }}
+        >
+          main
+        </span>
+      </span>
+    </div>
+  );
+}
+
+// ── Main Slide Component ──────────────────────────────────────────────────────
+function FeedbackLoopSlide() {
+  const { act } = useSlideActs();
+
+  // Build #2139: running at act 1, fails at act 2+
+  const build1Status: CIStatus = act >= 2 ? 'failure' : 'running';
+  // Build #2145: running at act 3, passes at act 4+
+  const build2Status: CIStatus = act >= 4 ? 'success' : 'running';
+
+  return (
+    // Scroll container — full slide height, zoom applied here
+    <div
+      className={sans.className}
+      style={{
+        height: '100%',
+        overflowY: 'auto',
+        paddingRight: 2,
+        zoom: 1.05,
+      }}
+    >
+      {/* Inner flex column — height shrinks to content so spine ends at last card */}
+      <div
+        style={{
+          position: 'relative',
+          display: 'flex',
+          flexDirection: 'column',
+          gap: 10,
+        }}
+      >
+        {/* Timeline spine — z-index 0 so avatars (z-index 1) render on top */}
+        <div
+          style={{
+            position: 'absolute',
+            top: 12,
+            bottom: 12,
+            left: 11.5,
+            width: 1,
+            background: EDGE,
+            pointerEvents: 'none',
+            zIndex: 0,
+          }}
+        />
+
+      <AnimatePresence initial={false}>
+
+        {/* Act 0 — PR Header */}
+        {act >= 0 && (
+          <motion.div key="pr-header" {...ENTER}>
+            <PRHeaderCard />
+          </motion.div>
+        )}
+
+        {/* Act 1 — Build #2139 starts running */}
+        {act >= 1 && (
+          <motion.div key="ci-build-1" {...ENTER}>
+            <CIRow
+              status={build1Status}
+              runLabel="build #2139 · unit-tests"
+              duration={act >= 2 ? '32s' : undefined}
+            />
+          </motion.div>
+        )}
+
+        {/* Act 2 — Build #2139 FAILS + agent pushes fix */}
+        {act >= 2 && (
+          <motion.div key="agent-fix-1" {...ENTER}>
+            <CommitPushRow
+              hash="e2f8a1c"
+              message="fix: correct yaml indentation in cache step"
+            />
+          </motion.div>
+        )}
+
+        {/* Act 3 — Build #2145 starts running */}
+        {act >= 3 && (
+          <motion.div key="ci-build-2" {...ENTER}>
+            <CIRow
+              status={build2Status}
+              runLabel="build #2145 · unit-tests"
+              duration={act >= 4 ? '87s' : undefined}
+            />
+          </motion.div>
+        )}
+
+        {/* Act 5 — cursor[bot] review comment */}
+        {act >= 5 && (
+          <motion.div key="cursor-comment" {...ENTER}>
+            <CommentCard
+              initials="C"
+              handle="cursor[bot]"
+              timestamp="T+9 min"
+              leftBorderColor={BLUE_BORDER}
+              avatarColor={BLUE}
+              resolved={act >= 6}
+            >
+              <span style={{ color: MUTED }}>Suggested change —</span>
+              <br />
+              Cache key is missing the lockfile hash. You&apos;ll get false cache hits
+              when dependencies change between runs.
+              <br />
+              <span style={{ color: GHOST, fontSize: 10 }}>
+                Consider:{' '}
+                <span style={{ color: BLUE }}>
+                  {'{{ runner.os }}-{{ hashFiles(\'**/yarn.lock\') }}'}
+                </span>
+              </span>
+            </CommentCard>
+          </motion.div>
+        )}
+
+        {/* Act 6 — Agent commits fix + resolves cursor[bot] thread */}
+        {act >= 6 && (
+          <motion.div key="agent-fix-2" {...ENTER}>
+            <CommitPushRow
+              hash="abc1234"
+              message="fix: add lockfile hash to cache key"
+            />
+          </motion.div>
+        )}
+
+        {act >= 6 && (
+          <motion.div key="agent-resolve" {...ENTER} transition={{ ...ENTER.transition, delay: 0.12 }}>
+            <CommentCard
+              initials="PO"
+              handle="pipeline-optimizer-agent[bot]"
+              timestamp="T+10 min"
+              leftBorderColor={TEAL}
+              avatarColor={TEAL}
+            >
+              Fixed in commit{' '}
+              <span
+                style={{
+                  color: TEAL,
+                  background: TEAL_BG,
+                  padding: '1px 4px',
+                  borderRadius: 3,
+                  fontWeight: 600,
+                }}
+              >
+                abc1234
+              </span>
+              . Resolved.{' '}
+              <span
+                style={{
+                  display: 'inline-flex',
+                  alignItems: 'center',
+                  gap: 3,
+                  background: TEAL_BG,
+                  border: `1px solid ${TEAL_BORDER}`,
+                  borderRadius: 10,
+                  padding: '1px 6px',
+                  fontSize: 9.5,
+                  color: TEAL,
+                  fontWeight: 600,
+                  verticalAlign: 'middle',
+                }}
+              >
+                <Check size={8} strokeWidth={3} />
+                Resolved
+              </span>
+            </CommentCard>
+          </motion.div>
+        )}
+
+        {/* Act 7 — Agent verification comment */}
+        {act >= 7 && (
+          <motion.div key="agent-verify" {...ENTER}>
+            <CommentCard
+              initials="PO"
+              handle="pipeline-optimizer-agent[bot]"
+              timestamp="T+8 min"
+              leftBorderColor={TEAL}
+              avatarColor={TEAL}
+              badge="Verified"
+            >
+              I verified this works. Build{' '}
+              <span style={{ color: TEAL, fontWeight: 600 }}>#2145</span>{' '}
+              passed in 87s — no regressions, cache hit confirmed.
+            </CommentCard>
+          </motion.div>
+        )}
+
+        {/* Act 8 — Merge badge + punchline */}
+        {act >= 8 && (
+          <motion.div key="merge-badge" {...ENTER}>
+            <MergeBadge />
+          </motion.div>
+        )}
+
+        {act >= 8 && (
+          <motion.div key="punchline" {...ENTER} transition={{ ...ENTER.transition, delay: 0.18 }}>
+            <div
+              style={{
+                fontFamily: 'monospace',
+                fontSize: 10.5,
+                color: GHOST,
+                fontStyle: 'italic',
+                paddingLeft: 34,
+                lineHeight: 1.5,
+              }}
+            >
+              CI failed.{' '}
+              <span style={{ color: MUTED }}>Agent fixed it.</span>
+              {'  '}cursor[bot] flagged.{' '}
+              <span style={{ color: MUTED }}>Agent fixed that too.</span>
+              {'  '}The loop closed without you.
+            </div>
+          </motion.div>
+        )}
+
+      </AnimatePresence>
+      </div>{/* end inner flex column */}
+    </div>
+  );
+}
+
+// ── Slide export ──────────────────────────────────────────────────────────────
+const feedbackLoopSlides: SlideData[] = [
+  {
+    id: 20,
+    title: 'The verification loop',
+    acts: 9,
+    content: <FeedbackLoopSlide />,
+    notes:
+      "This is a sanitized real PR from the pipeline-optimizer system. The agent opens the PR. CI fires — build #2139. It fails.\n\nThe agent reads its own CI failure, identifies the issue — a YAML indentation error in the cache step — pushes a fix commit, and CI fires again. Build #2145 passes.\n\nThen cursor[bot] posts a code review comment. Not a human. Another bot. It catches something the pipeline-optimizer missed in the implementation: the cache key doesn't include the lockfile hash. False cache hits when dependencies change.\n\nThe pipeline-optimizer reads the comment, pushes a second fix — abc1234 — and resolves the thread itself. No human mediation. No Slack message.\n\nMerged.\n\nTwo verification cycles. Both closed by the agent. That's the loop. And the critical point: neither cycle required a human. The agent caught its own CI failure. An AI reviewer caught a correctness bug. The agent resolved it. You're watching the trust threshold play out in real time — the system didn't ship broken code, but it also didn't need you to tell it that.",
+  },
+];
+
+export default feedbackLoopSlides;

--- a/src/components/talks/pipeline-optimizer/slides/07-results.tsx
+++ b/src/components/talks/pipeline-optimizer/slides/07-results.tsx
@@ -1,0 +1,268 @@
+'use client';
+// results-regrounder: slides/07-results.tsx → slot 14 (receipts / proof beat)
+import React from 'react';
+import { motion } from 'framer-motion';
+import type { SlideData } from './_types';
+import { useSlideActs } from '../slide-acts-context';
+import { sans } from '@/lib/fonts';
+
+// ── Brand ─────────────────────────────────────────────────────────────────────
+const TEAL     = 'rgb(0,175,154)';
+const PINK     = 'rgb(255,167,196)';
+const PINK_DIM = 'rgba(255,167,196,0.55)';
+
+// ── Types ─────────────────────────────────────────────────────────────────────
+
+type PlaybookKind = 'parallelization' | 'standard' | 'reliability';
+
+interface PlaybookRow {
+  slug: string;       // actual playbook id from the codebase
+  kind: PlaybookKind;
+  before: string;
+  after: string;
+  pct: string;
+}
+
+interface PlaybookGroup {
+  kind: PlaybookKind;
+  rows: PlaybookRow[];
+}
+
+// ── Win data — organized by PlaybookKind ──────────────────────────────────────
+// Numbers sourced from docs/savings/2026-05-23.md (and 2026-04-24.md).
+// "Clean" = single-playbook PR; "combined" = multiple playbooks in same repo window.
+//
+// TODO(tulsi): minimize-sequential-wait row uses arbor Apr-24 combined result
+//   (5-playbook bundle); isolate individual contribution before the talk if possible.
+// TODO(tulsi): monorepo-skip-unchanged row uses cmp Apr-27 combined result
+//   (dockerfile-optimization + monorepo-skip-unchanged + docker-compose-plugin).
+
+const GROUPS: PlaybookGroup[] = [
+  {
+    kind: 'parallelization',
+    rows: [
+      // arbor Apr 2026 · 5-playbook bundle incl. minimize-sequential-wait · feature 81 builds
+      { slug: 'minimize-sequential-wait', kind: 'parallelization', before: '13 min', after: '5 min', pct: '−62%' },
+    ],
+  },
+  {
+    kind: 'standard',
+    rows: [
+      // frontyard Apr 2026 · artifact-caching only · feature 2,832 builds ✓ clean
+      { slug: 'artifact-caching',        kind: 'standard', before: '14 min', after: '7 min', pct: '−49%' },
+      // chat Apr 2026 · buildkit-registry-cache only · feature 1,101 builds ✓ clean
+      { slug: 'buildkit-registry-cache', kind: 'standard', before: '6 min',  after: '4 min', pct: '−32%' },
+      // cmp Apr 2026 · 3 standard playbooks combined · feature 131 builds
+      { slug: 'monorepo-skip-unchanged', kind: 'standard', before: '22 min', after: '8 min', pct: '−63%' },
+    ],
+  },
+  {
+    kind: 'reliability',
+    rows: [
+      { slug: 'automatic-retry',     kind: 'reliability', before: '—', after: '—', pct: 'no reruns' },
+      { slug: 'assign-upload-queue', kind: 'reliability', before: '—', after: '—', pct: 'no reruns' },
+    ],
+  },
+];
+
+// ── Helpers ───────────────────────────────────────────────────────────────────
+
+function kindColor(kind: PlaybookKind): string {
+  if (kind === 'parallelization') return TEAL;
+  if (kind === 'reliability')     return PINK;
+  return 'rgba(255,255,255,0.45)';
+}
+
+function kindLabel(kind: PlaybookKind): string {
+  if (kind === 'parallelization') return 'parallelization';
+  if (kind === 'reliability')     return 'reliability';
+  return 'standard';
+}
+
+// ── Sub-components ────────────────────────────────────────────────────────────
+
+function KindTag({ kind, visible }: { kind: PlaybookKind; visible: boolean }) {
+  const color = kindColor(kind);
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: visible ? 1 : 0 }}
+      transition={{ duration: 0.22, ease: 'easeOut' }}
+      className="font-mono text-[9.5px] uppercase tracking-[0.18em] px-4 pt-2.5 pb-0.5"
+      style={{ color: color.replace('rgb', 'rgba').replace(')', ', 0.6)').replace('rgba(rgba', 'rgba') }}
+    >
+      {kindLabel(kind)}
+    </motion.div>
+  );
+}
+
+function PlaybookRow({
+  row,
+  visible,
+  delay = 0,
+}: {
+  row: PlaybookRow;
+  visible: boolean;
+  delay?: number;
+}) {
+  const isReliability = row.kind === 'reliability';
+
+  return (
+    <motion.div
+      initial={{ opacity: 0, x: -8 }}
+      animate={{ opacity: visible ? 1 : 0, x: visible ? 0 : -8 }}
+      transition={{ duration: 0.30, delay, ease: 'easeOut' }}
+      className="grid items-center gap-x-4 py-1 px-4"
+      style={{ gridTemplateColumns: '1fr auto auto auto' }}
+    >
+      {/* slug */}
+      <span
+        className="font-mono text-[12.5px] truncate"
+        style={{ color: isReliability ? 'rgba(255,255,255,0.45)' : 'rgba(255,255,255,0.80)' }}
+      >
+        {row.slug}
+      </span>
+
+      {/* before */}
+      <span className="font-mono text-[12px] text-white/25 text-right tabular-nums">
+        {row.before}
+      </span>
+
+      {/* after */}
+      <span className="font-mono text-[12px] text-white/50 text-right tabular-nums">
+        {isReliability ? '' : `→ ${row.after}`}
+      </span>
+
+      {/* pct / outcome */}
+      <span
+        className="font-mono text-[12.5px] font-bold text-right tabular-nums"
+        style={{
+          color: isReliability ? PINK_DIM : TEAL,
+          minWidth: '4.5rem',
+        }}
+      >
+        {row.pct}
+      </span>
+    </motion.div>
+  );
+}
+
+function Divider({ visible }: { visible: boolean }) {
+  return (
+    <motion.div
+      initial={{ opacity: 0 }}
+      animate={{ opacity: visible ? 1 : 0 }}
+      transition={{ duration: 0.18, delay: 0.1 }}
+      className="border-t border-white/8 mt-1.5 mx-4"
+    />
+  );
+}
+
+// ── Main slide component ──────────────────────────────────────────────────────
+
+function ResultsReceipt() {
+  const { act } = useSlideActs();
+
+  // act 0 → empty
+  // act 1 → header + parallelization group
+  // act 2 → + standard group
+  // act 3 → + reliability group
+  // act 4 → + totals bar + honesty note
+
+  const fadeIn = (atAct: number, delay = 0) => ({
+    initial: { opacity: 0 },
+    animate: { opacity: act >= atAct ? 1 : 0 },
+    transition: { duration: 0.35, delay, ease: 'easeOut' as const },
+  });
+
+  // map group index → act it reveals at
+  const groupAct = [1, 2, 3];
+
+  return (
+    <div
+      className={`${sans.className} flex flex-col h-full w-full justify-center max-w-2xl mx-auto`}
+    >
+      {/* ── Receipt header ─────────────────────────────────────────────────── */}
+      <motion.div
+        {...fadeIn(1)}
+        className="font-mono text-[9.5px] uppercase tracking-[0.22em] text-white/22 px-4 mb-3 flex justify-between"
+      >
+        <span>autonomous agent · first month · best case per playbook</span>
+        <span>before → after</span>
+      </motion.div>
+
+      {/* ── Groups ─────────────────────────────────────────────────────────── */}
+      <div
+        className="border border-white/10 rounded-lg overflow-hidden"
+        style={{ background: 'rgba(255,255,255,0.022)' }}
+      >
+        {GROUPS.map((group, gi) => {
+          const revealAct = groupAct[gi];
+          const isLast    = gi === GROUPS.length - 1;
+          return (
+            <React.Fragment key={group.kind}>
+              <KindTag kind={group.kind} visible={act >= revealAct} />
+              {group.rows.map((row, ri) => (
+                <PlaybookRow
+                  key={row.slug}
+                  row={row}
+                  visible={act >= revealAct}
+                  delay={ri * 0.05}
+                />
+              ))}
+              {!isLast && <Divider visible={act >= revealAct} />}
+            </React.Fragment>
+          );
+        })}
+
+        {/* ── Totals bar ──────────────────────────────────────────────────── */}
+        <motion.div
+          {...fadeIn(4)}
+          className="border-t border-white/12 mt-1 px-4 py-2.5 flex justify-between items-baseline"
+          style={{ background: 'rgba(0,175,154,0.05)' }}
+        >
+          <span className="font-mono text-[10.5px] text-white/38">
+            80+ PRs merged &nbsp;·&nbsp; 20+ repos &nbsp;·&nbsp; 12 playbooks &nbsp;·&nbsp; Buildkite-verified
+          </span>
+          <span className="font-mono text-[10.5px]" style={{ color: 'rgba(0,175,154,0.58)' }}>
+            ~6 showed ∅ improvement
+          </span>
+        </motion.div>
+      </div>
+
+      {/* ── Honesty footnote ───────────────────────────────────────────────── */}
+      <motion.div
+        initial={{ opacity: 0, y: 5 }}
+        animate={{ opacity: act >= 4 ? 1 : 0, y: act >= 4 ? 0 : 5 }}
+        transition={{ duration: 0.4, delay: 0.12, ease: 'easeOut' }}
+        className="text-sm text-white/38 italic text-center mt-4"
+      >
+        The system reports its non-wins. Every PR ships verification hints — pass or fail.
+      </motion.div>
+    </div>
+  );
+}
+
+// ── Slide data export ─────────────────────────────────────────────────────────
+
+const slides: SlideData[] = [
+  {
+    id: 12,
+    acts: 5,
+    title: 'What shipped',
+    content: <ResultsReceipt />,
+    notes: `Here's what shipped — organized by what the agent actually did, not where.
+
+Parallelization: minimize-sequential-wait identifies independent pipeline steps that are blocked behind each other and restructures them to run concurrently. Best result: a feature branch that was taking 13 minutes averaged 5 minutes after. That's a 62% reduction on every PR in that repo.
+
+Standard optimizations: artifact-caching — adding proper cache keys to install and build steps — cut a high-traffic feature pipeline from 14 minutes to 7. 2,800-plus builds measured. buildkit-registry-cache persisted Docker layer cache into the registry so cold builds stopped being painful: 6 minutes to 4 on another repo's feature runs across a thousand-plus builds. monorepo-skip-unchanged skips CI steps entirely when the relevant files haven't changed; best combined result: 22 minutes to 8.
+
+Reliability: automatic-retry and assign-upload-queue don't save time per run — they prevent failures that force reruns. No time metric, but flaky reruns multiply wasted time across every developer.
+
+Eighty-plus PRs across twenty-plus repos, all 12 playbooks active, every one verified against the actual Buildkite logs post-merge.
+
+Roughly six PRs showed no measurable improvement. The system reports those too.`,
+  },
+];
+
+export default slides;

--- a/src/components/talks/pipeline-optimizer/slides/07-results.tsx
+++ b/src/components/talks/pipeline-optimizer/slides/07-results.tsx
@@ -88,7 +88,7 @@ function KindTag({ kind, visible }: { kind: PlaybookKind; visible: boolean }) {
       initial={{ opacity: 0 }}
       animate={{ opacity: visible ? 1 : 0 }}
       transition={{ duration: 0.22, ease: 'easeOut' }}
-      className="font-mono text-[9.5px] uppercase tracking-[0.18em] px-4 pt-2.5 pb-0.5"
+      className="font-mono text-[11px] uppercase tracking-[0.18em] px-4 pt-3 pb-0.5"
       style={{ color: color.replace('rgb', 'rgba').replace(')', ', 0.6)').replace('rgba(rgba', 'rgba') }}
     >
       {kindLabel(kind)}
@@ -112,30 +112,30 @@ function PlaybookRow({
       initial={{ opacity: 0, x: -8 }}
       animate={{ opacity: visible ? 1 : 0, x: visible ? 0 : -8 }}
       transition={{ duration: 0.30, delay, ease: 'easeOut' }}
-      className="grid items-center gap-x-4 py-1 px-4"
+      className="grid items-center gap-x-4 py-1.5 px-4"
       style={{ gridTemplateColumns: '1fr auto auto auto' }}
     >
       {/* slug */}
       <span
-        className="font-mono text-[12.5px] truncate"
-        style={{ color: isReliability ? 'rgba(255,255,255,0.45)' : 'rgba(255,255,255,0.80)' }}
+        className="font-mono text-[14px] truncate"
+        style={{ color: isReliability ? 'rgba(255,255,255,0.55)' : 'rgba(255,255,255,0.85)' }}
       >
         {row.slug}
       </span>
 
       {/* before */}
-      <span className="font-mono text-[12px] text-white/25 text-right tabular-nums">
+      <span className="font-mono text-[13.5px] text-white/40 text-right tabular-nums">
         {row.before}
       </span>
 
       {/* after */}
-      <span className="font-mono text-[12px] text-white/50 text-right tabular-nums">
+      <span className="font-mono text-[13.5px] text-white/60 text-right tabular-nums">
         {isReliability ? '' : `→ ${row.after}`}
       </span>
 
       {/* pct / outcome */}
       <span
-        className="font-mono text-[12.5px] font-bold text-right tabular-nums"
+        className="font-mono text-[14px] font-bold text-right tabular-nums"
         style={{
           color: isReliability ? PINK_DIM : TEAL,
           minWidth: '4.5rem',
@@ -180,12 +180,12 @@ function ResultsReceipt() {
 
   return (
     <div
-      className={`${sans.className} flex flex-col h-full w-full justify-center max-w-2xl mx-auto`}
+      className={`${sans.className} flex flex-col h-full w-full justify-center max-w-3xl mx-auto`}
     >
       {/* ── Receipt header ─────────────────────────────────────────────────── */}
       <motion.div
         {...fadeIn(1)}
-        className="font-mono text-[9.5px] uppercase tracking-[0.22em] text-white/22 px-4 mb-3 flex justify-between"
+        className="font-mono text-[11px] uppercase tracking-[0.22em] text-white/40 px-4 mb-3 flex justify-between"
       >
         <span>autonomous agent · first month · best case per playbook</span>
         <span>before → after</span>
@@ -221,10 +221,10 @@ function ResultsReceipt() {
           className="border-t border-white/12 mt-1 px-4 py-2.5 flex justify-between items-baseline"
           style={{ background: 'rgba(0,175,154,0.05)' }}
         >
-          <span className="font-mono text-[10.5px] text-white/38">
+          <span className="font-mono text-[12px] text-white/60">
             80+ PRs merged &nbsp;·&nbsp; 20+ repos &nbsp;·&nbsp; 12 playbooks &nbsp;·&nbsp; Buildkite-verified
           </span>
-          <span className="font-mono text-[10.5px]" style={{ color: 'rgba(0,175,154,0.58)' }}>
+          <span className="font-mono text-[12px]" style={{ color: 'rgba(0,175,154,0.75)' }}>
             ~6 showed ∅ improvement
           </span>
         </motion.div>
@@ -235,7 +235,7 @@ function ResultsReceipt() {
         initial={{ opacity: 0, y: 5 }}
         animate={{ opacity: act >= 4 ? 1 : 0, y: act >= 4 ? 0 : 5 }}
         transition={{ duration: 0.4, delay: 0.12, ease: 'easeOut' }}
-        className="text-sm text-white/38 italic text-center mt-4"
+        className="text-sm text-white/65 italic text-center mt-4"
       >
         The system reports its non-wins. Every PR ships verification hints — pass or fail.
       </motion.div>

--- a/src/components/talks/pipeline-optimizer/slides/07-results.tsx
+++ b/src/components/talks/pipeline-optimizer/slides/07-results.tsx
@@ -70,13 +70,14 @@ const GROUPS: PlaybookGroup[] = [
 function kindColor(kind: PlaybookKind): string {
   if (kind === 'parallelization') return TEAL;
   if (kind === 'reliability')     return PINK;
-  return 'rgba(255,255,255,0.45)';
+  // NOTE: must be rgb(...), not rgba(...) — KindTag's color transform breaks on rgba inputs
+  return 'rgb(255,255,255)';
 }
 
 function kindLabel(kind: PlaybookKind): string {
   if (kind === 'parallelization') return 'parallelization';
   if (kind === 'reliability')     return 'reliability';
-  return 'standard';
+  return 'caching';
 }
 
 // ── Sub-components ────────────────────────────────────────────────────────────

--- a/src/components/talks/pipeline-optimizer/slides/08-lessons.tsx
+++ b/src/components/talks/pipeline-optimizer/slides/08-lessons.tsx
@@ -125,7 +125,7 @@ function AutoresearchSlide() {
               className="font-mono text-[11px] mb-1 px-2 py-1 rounded inline-block"
               style={{ background: 'rgba(0,175,154,0.12)', color: 'rgba(255,255,255,0.75)' }}
             >
-              "do not spawn sub-agents"
+              &quot;do not spawn sub-agents&quot;
             </div>
             <div className={`${sans.className} text-xs text-white/55 mt-1`}>
               turn variance collapsed
@@ -137,7 +137,7 @@ function AutoresearchSlide() {
         <div
           className={`${sans.className} text-xs text-white/40 mt-4 pt-3 border-t border-white/10 italic`}
         >
-          What's obvious to humans isn't obvious to agents. Spell it out.
+          What&apos;s obvious to humans isn&apos;t obvious to agents. Spell it out.
         </div>
       </motion.div>
 

--- a/src/components/talks/pipeline-optimizer/slides/08-lessons.tsx
+++ b/src/components/talks/pipeline-optimizer/slides/08-lessons.tsx
@@ -1,0 +1,171 @@
+// porter-C: slides/08-lessons.md → slide Learning #3
+// Gotchas (id 13) and Three Lessons (id 15) removed per deck restructure.
+import React from 'react';
+import { motion } from 'framer-motion';
+import type { SlideData } from './_types';
+import { useSlideActs } from '../slide-acts-context';
+import { sans } from '@/lib/fonts';
+
+// ── Slide — Learning #3: AutoResearch — the agent that debugs agents ──────────
+const traceDots = Array.from({ length: 14 }, (_, i) => ({ wasted: i >= 10 }));
+
+function AutoresearchSlide() {
+  const { act } = useSlideActs();
+
+  const fadeIn = (atAct: number) => ({
+    initial: { opacity: 0, y: 8 },
+    animate: { opacity: act >= atAct ? 1 : 0, y: act >= atAct ? 0 : 8 },
+    transition: { duration: 0.35, ease: 'easeOut' as const },
+  });
+
+  return (
+    <div className="flex flex-col h-full w-full gap-4">
+      {/* Row 1 — implementation agent + trace dots */}
+      <motion.div
+        {...fadeIn(1)}
+        className="border border-white/15 rounded-lg px-5 py-4 flex items-center gap-5"
+      >
+        <div className="font-mono text-[11px] text-white/40 uppercase tracking-widest w-36 shrink-0">
+          impl. agent run
+        </div>
+        <div className="flex gap-1.5 items-center flex-1">
+          {traceDots.map((d, i) => (
+            <div
+              key={i}
+              className="w-2 h-2 rounded-full shrink-0"
+              style={{
+                backgroundColor: d.wasted ? 'rgba(255,167,196,0.65)' : 'rgba(255,255,255,0.22)',
+              }}
+            />
+          ))}
+          <div className={`${sans.className} text-xs text-white/40 ml-3 shrink-0`}>
+            200+ turns
+          </div>
+        </div>
+        <div className="font-mono text-xs shrink-0" style={{ color: 'rgba(255,167,196,0.8)' }}>
+          ~50% success
+        </div>
+      </motion.div>
+
+      {/* Connector */}
+      <motion.div {...fadeIn(2)} className="flex items-center gap-3 pl-5">
+        <div className="w-px h-4 bg-white/20" />
+        <div className="font-mono text-[10px] text-white/30 uppercase tracking-widest">
+          traces logged → autoresearch skill invoked
+        </div>
+      </motion.div>
+
+      {/* Row 2 — autoresearch skill */}
+      <motion.div
+        {...fadeIn(2)}
+        className="border rounded-lg px-5 py-4 flex items-center gap-5"
+        style={{ borderColor: 'rgba(0,175,154,0.45)' }}
+      >
+        <div
+          className="font-mono text-[11px] uppercase tracking-widest w-36 shrink-0"
+          style={{ color: 'rgb(0,175,154)' }}
+        >
+          autoresearch
+        </div>
+        <div className={`${sans.className} text-sm text-white/60`}>
+          reads turn-by-turn traces · finds repeated failures · proposes targeted fix
+        </div>
+      </motion.div>
+
+      {/* Diagnosis + before/after card */}
+      <motion.div {...fadeIn(3)} className="border border-white/10 rounded-lg px-5 py-4 ml-8">
+        {/* Diagnosis chip */}
+        <div className="font-mono text-[10px] text-white/35 uppercase tracking-widest mb-4">
+          diagnosis: turn counts spiked above cap · sub-agents inheriting unbounded budgets
+        </div>
+
+        {/* Before / After columns */}
+        <div className="flex gap-6">
+          {/* Before */}
+          <div className="flex-1">
+            <div className="font-mono text-[10px] text-white/30 mb-2">before</div>
+            {/* Spiking bar chart */}
+            <div className="flex gap-[3px] items-end h-9 mb-2">
+              {[3, 4, 3, 5, 4, 7, 9, 13, 10, 14, 11, 13].map((h, i) => (
+                <div
+                  key={i}
+                  className="w-1.5 rounded-sm shrink-0"
+                  style={{
+                    height: `${h * 2.4}px`,
+                    backgroundColor:
+                      h > 7 ? 'rgba(255,167,196,0.65)' : 'rgba(255,255,255,0.22)',
+                  }}
+                />
+              ))}
+            </div>
+            <div className={`${sans.className} text-xs text-white/55 leading-relaxed`}>
+              turn explosion per run<br />
+              inconsistent re-runs · cost variance
+            </div>
+          </div>
+
+          <div className="border-l border-white/10 pl-6 flex-1">
+            <div className="font-mono text-[10px] mb-2" style={{ color: 'rgb(0,175,154)' }}>
+              after fix
+            </div>
+            {/* Flat bar chart */}
+            <div className="flex gap-[3px] items-end h-9 mb-2">
+              {[4, 4, 3, 4, 4, 3, 4, 4, 3, 4, 4, 3].map((h, i) => (
+                <div
+                  key={i}
+                  className="w-1.5 rounded-sm shrink-0"
+                  style={{
+                    height: `${h * 2.4}px`,
+                    backgroundColor: 'rgba(0,175,154,0.5)',
+                  }}
+                />
+              ))}
+            </div>
+            <div
+              className="font-mono text-[11px] mb-1 px-2 py-1 rounded inline-block"
+              style={{ background: 'rgba(0,175,154,0.12)', color: 'rgba(255,255,255,0.75)' }}
+            >
+              "do not spawn sub-agents"
+            </div>
+            <div className={`${sans.className} text-xs text-white/55 mt-1`}>
+              turn variance collapsed
+            </div>
+          </div>
+        </div>
+
+        {/* Punchline */}
+        <div
+          className={`${sans.className} text-xs text-white/40 mt-4 pt-3 border-t border-white/10 italic`}
+        >
+          What's obvious to humans isn't obvious to agents. Spell it out.
+        </div>
+      </motion.div>
+
+      {/* Loop closes */}
+      <motion.div {...fadeIn(4)} className="flex flex-col gap-2 mt-1">
+        <div className="flex items-center gap-2">
+          <span className="font-mono text-white/35 text-base">↺</span>
+          <div className="font-mono text-[10px] text-white/35 uppercase tracking-widest">
+            loop closes — no human reviewed the traces
+          </div>
+        </div>
+        <div className={`${sans.className} text-lg italic text-white/70`}>
+          The system debugs itself.
+        </div>
+      </motion.div>
+    </div>
+  );
+}
+
+const slides: SlideData[] = [
+  {
+    id: 14,
+    title: 'Learning #3: AutoResearch — the agent that debugs agents',
+    acts: 5,
+    content: <AutoresearchSlide />,
+    notes:
+      "Observability is what made this whole feedback loop possible. Each agent run produces a full turn-by-turn trace. We wired those through Datadog LLM Observability, so every agent decision is inspectable. Then I built a custom Claude Code skill — a SKILL.md file in the project — that, when invoked, reads those traces and proposes specific improvements. Claude Code skills are an off-the-shelf mechanism: define the skill file, reference it in your CLAUDE.md, invoke it with the Skill tool. One of the first things autoresearch caught: turn counts spiking well above the configured cap, inconsistently across re-runs of the same repo. Tracing showed why — the fix agent was spawning sub-agents when it encountered repos with multiple pipeline directories. Sub-agent turns aren't bounded by the parent's turn cap. The fix was a single line added to the agent's prompt: 'do not spawn sub-agents'. Turn variance collapsed immediately. What's interesting here is that no human would think to write that constraint. It's completely obvious if you're a human — of course you don't spin up children that bypass your budget. But the model doesn't know that. It sees parallel work as helpful. Only autoresearch catches this — it shows up in the trace shape, not in the output. The design principle: the system owns correctness, not the playbook text. If the same mistake recurs across runs and repos, that's a signal about the system's design — a missing constraint, a missing tool, a missing feedback mechanism.\n\nTransferable building blocks for the audience: Claude Agent SDK (off-the-shelf agentic execution loop) · MCP Model Context Protocol (open standard for agent tool surfaces) · Datadog LLM Observability or equivalent (LangSmith, Helicone) for agent trace inspection.",
+  },
+];
+
+export default slides;

--- a/src/components/talks/pipeline-optimizer/slides/09-close.tsx
+++ b/src/components/talks/pipeline-optimizer/slides/09-close.tsx
@@ -1,0 +1,26 @@
+// porter-C: slides/09-close.md → slide 19
+import React from 'react';
+import type { SlideData } from './_types';
+import { sans } from '@/lib/fonts';
+
+const slides: SlideData[] = [
+  // ── Slide 16 — Q&A ───────────────────────────────────────────────────────
+  // TODO(slide-designer): Full-bleed, dot-grid background (static). Identical aesthetic to
+  //   slide 01 — visual bookend. "Q&A" in same large mono as title card. Static, no animation.
+  {
+    id: 16,
+    title: undefined,
+    content: (
+      <div className="flex flex-col items-center justify-center h-full w-full text-center">
+        <h2 className={`${sans.className} text-7xl font-bold text-white mb-8`}>Q&amp;A</h2>
+        <div className="font-mono text-sm text-white/40">
+          <div>Tulsi Sapkota · @tolsee · tolsee.me</div>
+        </div>
+      </div>
+    ),
+    notes:
+      "Stay on this slide for the entire Q&A. If there's a natural moment to close before Q&A begins: \"To answer the title directly: yes, it replaced a real category of work I used to do manually. The interesting question isn't 'did it work.' It's 'what do you do now that the agent does the thing you used to do?' And the honest answer is: you build the next agent. You hold the bar higher. You give it harder problems. The job doesn't go away — it moves up a level. That's what I want to leave you with.\"",
+  },
+];
+
+export default slides;

--- a/src/components/talks/pipeline-optimizer/slides/_primitives.tsx
+++ b/src/components/talks/pipeline-optimizer/slides/_primitives.tsx
@@ -1,0 +1,22 @@
+import type { ReactNode } from 'react';
+
+export function Bullets({ items }: { items: string[] }) {
+  return (
+    <ul className="space-y-4 list-none mt-2">
+      {items.map((item, i) => (
+        <li key={i} className="flex gap-3 text-xl leading-snug text-white/85">
+          <span className="text-white/25 select-none flex-shrink-0 mt-0.5">–</span>
+          <span>{item}</span>
+        </li>
+      ))}
+    </ul>
+  );
+}
+
+export function MonoCallout({ children }: { children: ReactNode }) {
+  return (
+    <pre className="font-mono text-sm text-white/70 bg-white/5 border border-white/10 rounded p-4 leading-relaxed whitespace-pre-wrap mt-4">
+      {children}
+    </pre>
+  );
+}

--- a/src/components/talks/pipeline-optimizer/slides/_types.ts
+++ b/src/components/talks/pipeline-optimizer/slides/_types.ts
@@ -1,0 +1,10 @@
+import type { ReactNode } from 'react';
+
+export interface SlideData {
+  id: number;
+  title?: string;
+  content: ReactNode;
+  notes?: string;
+  /** Number of animation steps before → / Space moves to the next slide. Defaults to 1. */
+  acts?: number;
+}


### PR DESCRIPTION
## What's new

A complete Next.js presentation deck for Tulsi's external conference talk **"Replace Yourself with Agents"** — a 15-slide interactive deck built with Framer Motion, React, and Tailwind.

### Commits

- **Route + deck shell + shared primitives** — Next.js app route (`/talks/replace-yourself-with-agents`), presenter view, deck orchestrator, slide wrapper with acts/keyboard navigation, acts context, slides-data registry, shared `_primitives`/`_types`, and funnel animation utility
- **Slides 1–5** — What We Built (intro), Hook (broken CI before state), Naive/CI Cycle loop, Full Picture architecture diagram (progressive reveal), Why CI
- **Slides 6–8** — Playbooks (definition + principles + examples), vs-Alternatives comparison (Devin / Claude routines — control / customization / context / verification), Key Insight funnel, Feedback Loop (GitHub PR-style verification animation)
- **Slides 9–11** — Results (per-repo receipt ledger), Learnings × 3 (Learning #3 updated with autoresearch/sub-agents-spawning-unbounded-children example), Close / Q&A
- **deps** — `reactflow ^11.11.4` added for slide diagrams

### Excluded
- `talks/` (internal research docs, design sketches) — not committed
- `.claude/` (team configs, memory) — not committed

---

## Test plan

- [ ] Visit `/talks/replace-yourself-with-agents` — deck loads on slide 1
- [ ] Press `→` / `ArrowRight` — advances through all 15 slides in order
- [ ] Press `←` / `ArrowLeft` — navigates back
- [ ] On a multi-act slide, press `→` — reveals acts progressively before advancing to next slide
- [ ] Press `n` — toggles speaker notes overlay
- [ ] Press `f` — enters fullscreen
- [ ] Visit `/talks/replace-yourself-with-agents/presenter` — presenter view loads with notes visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>