### PR TITLE
polish(blog): richer listing + post header, fix card hover jitter

### DIFF
--- a/app/globals.css
+++ b/app/globals.css
@@ -80,6 +80,22 @@ span.glass-button:hover::after {
   display: none;
 }
 
+/* Text inside a link is clickable, not selectable — keep the pointer cursor
+   and drop the caret/selection bar so post rows don't feel like plain text. */
+a p:hover,
+a h1:hover,
+a h2:hover,
+a h3:hover {
+  cursor: pointer;
+}
+
+a p:hover::after,
+a h1:hover::after,
+a h2:hover::after,
+a h3:hover::after {
+  display: none;
+}
+
 /*
  * Copypasta from overreacted.io
  * */

--- a/app/posts/[slug]/page.tsx
+++ b/app/posts/[slug]/page.tsx
@@ -1,6 +1,8 @@
 import { getAllPosts, getPostBySlug } from '@/lib/api';
 import markdownToHtml from '@/lib/markdownToHtml';
 import { PostTitle } from '@/src/components/post/post-title';
+import { formatDate, readingTime, asTags } from '@/lib/utils';
+import Link from 'next/link';
 import { notFound } from 'next/navigation';
 
 import markdownStyles from './markdown-styles.module.css';
@@ -59,13 +61,38 @@ export async function generateMetadata(props: Params): Promise<Metadata> {
 
 export default async function Post({ params }: Params) {
   const { slug } = await params;
-  const post = await getPostBySlug(slug, ['title', 'author', 'content']);
+  const post = await getPostBySlug(slug, [
+    'title',
+    'author',
+    'content',
+    'publishedAt',
+    'tags',
+  ]);
   const content = await markdownToHtml(post.content || '');
+  const tags = asTags(post.tags);
 
   return (
     <div className="mx-auto">
       <main>
         <article>
+          <header className="mb-8">
+            <Link
+              href="/posts"
+              className="inline-flex items-center gap-1 text-sm text-muted-foreground transition-colors hover:text-[--green]"
+            >
+              <span aria-hidden>←</span> Blog
+            </Link>
+            <div className="mt-6 flex flex-wrap items-center gap-x-3 gap-y-2 text-sm text-muted-foreground">
+              {post.publishedAt && <span>{formatDate(post.publishedAt)}</span>}
+              <span aria-hidden>·</span>
+              <span>{readingTime(post.content || '')} min read</span>
+              {tags.map((tag) => (
+                <span key={tag} className="glass-pill text-xs">
+                  {tag}
+                </span>
+              ))}
+            </div>
+          </header>
           <PostTitle>{post.title}</PostTitle>
           <div
             dangerouslySetInnerHTML={{ __html: content }}

--- a/app/posts/page.tsx
+++ b/app/posts/page.tsx
@@ -1,5 +1,6 @@
 import Link from 'next/link';
-import { getAllPosts, Item } from '@/lib/api';
+import { getAllPosts } from '@/lib/api';
+import { formatDate, readingTime, asTags } from '@/lib/utils';
 
 export const metadata = {
   title: 'Blog',
@@ -7,48 +8,61 @@ export const metadata = {
 };
 
 export default async function BlogPage() {
-  const posts = await getAllPosts(['title', 'content', 'publishedAt', 'slug']);
+  const posts = await getAllPosts([
+    'title',
+    'content',
+    'publishedAt',
+    'tags',
+    'slug',
+  ]);
+
+  const sorted = posts.sort((a, b) =>
+    new Date(a.publishedAt) > new Date(b.publishedAt) ? -1 : 1,
+  );
 
   return (
     <section>
-      <h1 className="font-medium text-2xl mb-8 tracking-tighter">
-        Read my blog
-      </h1>
-      {posts
-        .sort((a, b) => {
-          if (new Date(a.publishedAt) > new Date(b.publishedAt)) {
-            return -1;
-          }
-          return 1;
-        })
-        .map((post) => (
-          <Link
-            key={post.slug}
-            className="block py-4 hover:scale-[1.005]"
-            href={'/posts/' + post.slug}
-          >
-            <article>
-              <PostTitle post={post} />
-              <PostMeta post={post} />
-            </article>
-          </Link>
+      <header className="mb-10">
+        <h1 className="text-4xl font-bold tracking-tighter">Read my blog</h1>
+        <p className="mt-2 text-muted-foreground">
+          Notes on software, tooling, and building things.
+        </p>
+      </header>
+
+      <ul className="divide-y divide-border">
+        {sorted.map((post) => (
+          <li key={post.slug}>
+            <Link href={`/posts/${post.slug}`} className="group block py-6">
+              <div className="flex items-baseline justify-between gap-4">
+                <h2 className="text-xl font-semibold tracking-tight transition-colors group-hover:text-[--green]">
+                  {post.title}
+                </h2>
+                <span
+                  aria-hidden
+                  className="hidden shrink-0 text-[--green] opacity-0 transition-all duration-200 group-hover:translate-x-1 group-hover:opacity-100 sm:inline"
+                >
+                  →
+                </span>
+              </div>
+              <p className="mt-2 line-clamp-2 text-muted-foreground">
+                {post.content.split(' ').slice(0, 28).join(' ')}…
+              </p>
+              <div className="mt-3 flex flex-wrap items-center gap-x-3 gap-y-2 text-[13px] text-muted-foreground">
+                <span>{formatDate(post.publishedAt)}</span>
+                <span aria-hidden>·</span>
+                <span>{readingTime(post.content)} min read</span>
+                {asTags(post.tags)
+                  .slice(0, 3)
+                  .map((tag) => (
+                    <span key={tag} className="glass-pill text-xs">
+                      {tag}
+                    </span>
+                  ))}
+              </div>
+            </Link>
+          </li>
         ))}
+      </ul>
     </section>
-  );
-}
-
-function PostTitle({ post }: { post: Item }) {
-  return <h2>{post.title}</h2>;
-}
-
-function PostMeta({ post }: { post: Item }) {
-  return (
-    <p className="text-[13px] text-gray-700 dark:text-gray-300">
-      {new Date(post.publishedAt).toLocaleDateString('en', {
-        day: 'numeric',
-        month: 'long',
-        year: 'numeric',
-      })}
-    </p>
   );
 }

--- a/lib/utils.ts
+++ b/lib/utils.ts
@@ -4,3 +4,23 @@ import { twMerge } from 'tailwind-merge';
 export function cn(...inputs: ClassValue[]) {
   return twMerge(clsx(inputs));
 }
+
+export function formatDate(date: string) {
+  return new Date(date).toLocaleDateString('en', {
+    day: 'numeric',
+    month: 'long',
+    year: 'numeric',
+  });
+}
+
+// ~200 wpm reading speed; always at least 1 min.
+export function readingTime(content: string) {
+  const words = content.trim().split(/\s+/).filter(Boolean).length;
+  return Math.max(1, Math.round(words / 200));
+}
+
+export function asTags(tags: unknown): string[] {
+  if (Array.isArray(tags)) return tags.map(String);
+  if (typeof tags === 'string' && tags.trim()) return [tags];
+  return [];
+}

--- a/src/components/animating-card.tsx
+++ b/src/components/animating-card.tsx
@@ -54,24 +54,34 @@ export function AnimatingCard({ children }: Props) {
     }, 100);
   };
 
+  // Pointer handlers live on a STATIC wrapper, not the tilted element.
+  // Tilting the card itself moved its hit-area at the edges, so the pointer
+  // flickered in/out and the tilt juddered. The wrapper never transforms, so
+  // mouseleave only fires when you actually leave the card — no jitter.
   return (
-    <motion.div
+    <div
       onMouseMove={animate}
       onMouseLeave={stopAnimating}
-      animate={{
-        rotateY: rotations.x,
-        rotateX: rotations.y,
-        transformPerspective: Math.max(100, rotations.z * 100),
-      }}
       style={{
         display: 'flex',
         alignItems: 'center',
         justifyContent: 'center',
-        transformStyle: 'preserve-3d',
-        transformOrigin: 'center',
       }}
     >
-      {children}
-    </motion.div>
+      <motion.div
+        animate={{
+          rotateY: rotations.x,
+          rotateX: rotations.y,
+          transformPerspective: Math.max(100, rotations.z * 100),
+        }}
+        style={{
+          width: '100%',
+          transformStyle: 'preserve-3d',
+          transformOrigin: 'center',
+        }}
+      >
+        {children}
+      </motion.div>
+    </div>
   );
 }

--- a/src/components/featured-projects.tsx
+++ b/src/components/featured-projects.tsx
@@ -39,12 +39,8 @@ const FEATURED_PROJECTS = [
     githubLink: 'https://github.com/Tolsee/tolsee.me',
     liveLink: 'https://tolsee.me',
     status: 'Active',
-    externalLinks: [
-      {
-        title: 'Live Site',
-        link: 'https://tolsee.me',
-      },
-    ],
+    // No "Live Site" link — visitors viewing this card are already on it.
+    externalLinks: [],
   },
   {
     title: 'Developer Dotfiles',


### PR DESCRIPTION
UX polish across the blog + project cards (keeps the existing minimal look, no identity change).

### /posts listing
- Each post now shows a 2-line excerpt, reading time, and tag pills, with dividers between entries.
- Hover uses a color shift + slide-in arrow instead of `scale` — no more edge jitter.

### Post detail
- "← Blog" back link.
- Meta header: publish date · reading time · tag pills.

### Card hover jitter (home)
- `AnimatingCard` moved its pointer handlers onto the *tilted* element, so at the edges the tilt shifted the hit-area and the pointer flickered in/out. Handlers now live on a static wrapper; the tilt is unchanged but stable.

### Project cards
- Removed the redundant **Live Site** button on the *Personal Website (tolsee.me)* card — visitors viewing it are already on the live site. Code button kept.

### Shared helpers
- `formatDate` / `readingTime` / `asTags` in `lib/utils.ts`.

Verified locally (`next dev`): post detail, listing, and projects screenshotted. `tsc --noEmit` + `eslint` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)