### PR TITLE
fix(posts): make code blocks visible (dark bg on <pre>)

### DIFF
--- a/app/posts/[slug]/prism-theme.css
+++ b/app/posts/[slug]/prism-theme.css
@@ -35,6 +35,13 @@ pre[class*='language-'] {
 pre[class*='language-'] {
   overflow: auto;
   padding: 1.3125rem;
+  /* Dark background lives directly on <pre> (not only on the .remark-highlight
+     wrapper). The wrapper isn't always emitted — self-escaped fences and any
+     grammar Prism can't load server-side fall through to a bare <pre>, and the
+     white code text was rendering invisibly on the white page. Same navy as
+     .remark-highlight so it's identical when the wrapper is present. */
+  background: #011627;
+  border-radius: 10px;
 }
 
 pre[class*='language-']::-moz-selection {


### PR DESCRIPTION
## What happened

Code fences on the blog rendered as **invisible white-on-white boxes** — only the grey overflow scrollbar was visible.

`prism-theme.css` sets `color: white; background: none` on `pre[class*='language-']`, and the dark background lived **only** on the `.remark-highlight` wrapper. That wrapper isn't in the output: self-escaped fences and any grammar Prism can't load server-side fall through to a bare `<pre>`, so every block was unreadable.

## Fix

Put the navy background (`#011627`, the same colour as `.remark-highlight`) + `border-radius` directly on `pre[class*='language-']`. Blocks are now visible whether or not the wrapper is emitted, and it's the identical colour when the wrapper *is* present (no double-background glitch).

## Verified

Injected the change on the live post and screenshotted — the `[WARN]…`, `theme = TokyoNight Moon`, and `nvim --headless …` blocks all render as white monospace on navy.

## Not in scope

Syntax *highlighting* (token colours) still isn't kicking in — Prism grammars aren't loading server-side, so everything self-escapes to plain text. Separate, deeper issue; this PR only restores readability.

🤖 Generated with [Claude Code](https://claude.com/claude-code)